### PR TITLE
dev to master merge, added docs/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+docs/
 book/
 .vscode


### PR DESCRIPTION
Now that the docs/ directory is removed from the repo, we can add docs/ in .gitignore.