### PR TITLE
Development terra ncloud

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -214,6 +214,7 @@
       - [SSH Connection with Wireguard](terraform/advanced/terraform_wireguard_ssh.md)
       - [Set a Wireguard VPN](terraform/advanced/terraform_wireguard_vpn.md)
       - [Synced MariaDB Databases](terraform/advanced/terraform_mariadb_synced_databases.md)
+      - [Nextcloud Single Deployment](terraform/advanced/terraform_nextcloud_single.md)
       - [Nextcloud Redundant Deployment](terraform/advanced/terraform_nextcloud_redundant.md)
   - [Advanced](advanced/advanced.md)
     - [Grid3 Stellar-TFChain Bridge](advanced/grid3_stellar_tfchain_bridge.md)

--- a/src/system_administrators/system_administrators.md
+++ b/src/system_administrators/system_administrators.md
@@ -90,6 +90,7 @@ From deployment strategies to monitoring tools, from security best practices to 
     - [SSH Connection with Wireguard](../terraform/advanced/terraform_wireguard_ssh.md)
     - [Set a Wireguard VPN](../terraform/advanced/terraform_wireguard_vpn.md)
     - [Synced MariaDB Databases](../terraform/advanced/terraform_mariadb_synced_databases.md)
+    - [Nextcloud Single Deployment](../terraform/advanced/terraform_nextcloud_single.md)
     - [Nextcloud Redundant Deployment](../terraform/advanced/terraform_nextcloud_redundant.md)
 - [Advanced](../advanced/advanced.md)
   - [Grid3 Stellar-TFChain Bridge](../advanced/grid3_stellar_tfchain_bridge.md)

--- a/src/terraform/advanced/terraform_advanced_readme.md
+++ b/src/terraform/advanced/terraform_advanced_readme.md
@@ -10,4 +10,5 @@
 - [SSH Connection with Wireguard](./terraform_wireguard_ssh.md)
 - [Set a Wireguard VPN](./terraform_wireguard_vpn.md)
 - [Synced MariaDB Databases](./terraform_mariadb_synced_databases.md)
+- [Nextcloud Single Deployment](./terraform_nextcloud_single.md)
 - [Nextcloud Redundant Deployment](./terraform_nextcloud_redundant.html)

--- a/src/terraform/advanced/terraform_nextcloud_redundant.md
+++ b/src/terraform/advanced/terraform_nextcloud_redundant.md
@@ -108,7 +108,7 @@ We thus start by finding two 3Nodes with sufficient resources. For this current 
     * `Free Public IP`: 2
       * Note: if you want a public IPv4 address, it is recommended to set the parameter `FREE PUBLIC IP` to at least 2 to avoid false positives. This ensures that the shown 3Nodes have viable IP addresses.
 
-Once you've found two proper nodes, take node of their node IDs. You will need to use those IDs when creating the Terraform files.
+Once you've found two 3Nodes, take note of their node IDs. You will need to use those IDs when creating the Terraform files.
 
 ***
 

--- a/src/terraform/advanced/terraform_nextcloud_redundant.md
+++ b/src/terraform/advanced/terraform_nextcloud_redundant.md
@@ -901,7 +901,7 @@ The Nextcloud database is synced in real-time on two different 3nodes. When one 
 
 You can now [install Nextcloud](https://nextcloud.com/install/) on your local computer. You will then be able to "use the desktop clients to keep your files synchronized between your Nextcloud server and your desktop". You can also do regular backups with Nextcloud to ensure maximum resilience of your data. Check Nextcloud's [documentation](https://docs.nextcloud.com/server/latest/admin_manual/maintenance/backup.html) for more information on this.
 
-You should now have a basic understanding of the Threefold Grid, GraphQL, Wireguard, Terraform, MariaDB, GlusterFS, PHP and Nextcloud. Now, you know how to deploy workloads on the Threefold Grid with an efficient architecture in order to ensure redundancy. This is just the beginning. The Threefold Grid has a somewhat infinite potential when it comes to deployments, workloads, architectures and server projects. Let's see where it goes from here!
+You should now have a basic understanding of the Threefold Grid, the ThreeFold Explorer, Wireguard, Terraform, MariaDB, GlusterFS, PHP and Nextcloud. Now, you know how to deploy workloads on the Threefold Grid with an efficient architecture in order to ensure redundancy. This is just the beginning. The Threefold Grid has a somewhat infinite potential when it comes to deployments, workloads, architectures and server projects. Let's see where it goes from here!
 
 This Nextcloud deployment could be improved in many ways and other guides might be published in the future with enhanced functionalities. Stay tuned for more Threefold Guides. If you have ideas on how to improve this guide, please let us know. We learn best when sharing knowledge.
 

--- a/src/terraform/advanced/terraform_nextcloud_single.md
+++ b/src/terraform/advanced/terraform_nextcloud_single.md
@@ -8,12 +8,12 @@
 - [Main Steps](#main-steps)
 - [Prerequisites](#prerequisites)
 - [Find a 3Node with the ThreeFold Explorer](#find-a-3node-with-the-threefold-explorer)
-- [Set the full VM](#set-the-full-vm)
+- [Set the Full VM](#set-the-full-vm)
   - [Overview](#overview)
   - [Create the Terraform Files](#create-the-terraform-files)
   - [Deploy the Full VM with Terraform](#deploy-the-full-vm-with-terraform)
   - [SSH into the 3Node](#ssh-into-the-3node)
-  - [Prepare the full VM](#prepare-the-full-vm)
+  - [Prepare the Full VM](#prepare-the-full-vm)
 - [Create the MariaDB Database](#create-the-mariadb-database)
   - [Download MariaDB and Configure the Database](#download-mariadb-and-configure-the-database)
   - [Set the Nextcloud User and Database](#set-the-nextcloud-user-and-database)
@@ -33,7 +33,7 @@
 
 # Introduction
 
-In this Threefold Guide, we deploy a [Nextcloud](https://nextcloud.com/) instance on a Full VM running on the [Threefold Grid](https://threefold.io/).
+In this Threefold Guide, we deploy a [Nextcloud](https://nextcloud.com/) instance on a full VM running on the [Threefold Grid](https://threefold.io/).
 
 We will learn how to deploy a full virtual machine (Ubuntu 22.04) with [Terraform](https://www.terraform.io/). We will install and deploy Nextcloud. We will add a DDNS (dynamic DNS) domain to the Nextcloud deployment. It will then be possible to connect to the Nextcloud instance over public internet. Nextcloud will be available over your computer and even your smart phone! We will also set HTTPS for the DDNS domain in order to make the Nextcloud instance as secure as possible. You are free to explore different DDNS options. In this guide, we will be using [DuckDNS](https://www.duckdns.org/) for simplicity.
 
@@ -97,7 +97,7 @@ Once you've found a 3Node, take note of its node ID. You will need to use this I
 
 ***
 
-# Set the full VM
+# Set the Full VM
 
 ## Overview
 
@@ -248,7 +248,7 @@ Make sure to add your own seed phrase and SSH public key. You will also need to 
 
 ## Deploy the Full VM with Terraform
 
-We now deploy the Full VM with Terraform. Make sure that you are in the correct folder `terraform/deployment-single-nextcloud` with the main and variables files.
+We now deploy the full VM with Terraform. Make sure that you are in the correct folder `terraform/deployment-single-nextcloud` with the main and variables files.
 
 * Initialize Terraform:
   *  ```
@@ -277,7 +277,7 @@ After deployments, take note of the 3Node's IPv4 address. You will need this add
       sudo ssh-add ~/.ssh/id_rsa
       ```
 
-## Prepare the full VM
+## Prepare the Full VM
 
 * Update and upgrade the system
   * ```

--- a/src/terraform/advanced/terraform_nextcloud_single.md
+++ b/src/terraform/advanced/terraform_nextcloud_single.md
@@ -7,27 +7,20 @@
 - [Introduction](#introduction)
 - [Main Steps](#main-steps)
 - [Prerequisites](#prerequisites)
-- [Find Nodes with the ThreeFold Explorer](#find-nodes-with-the-threefold-explorer)
-- [Set the VMs](#set-the-vms)
+- [Find a 3Node with the ThreeFold Explorer](#find-a-3node-with-the-threefold-explorer)
+- [Set the full VM](#set-the-full-vm)
   - [Overview](#overview)
   - [Create the Terraform Files](#create-the-terraform-files)
   - [Deploy the Full VM with Terraform](#deploy-the-full-vm-with-terraform)
   - [SSH into the 3Node](#ssh-into-the-3node)
-  - [Prepare the VM for the Deployment](#prepare-the-vm-for-the-deployment)
+  - [Prepare the full VM](#prepare-the-full-vm)
 - [Create the MariaDB Database](#create-the-mariadb-database)
   - [Download MariaDB and Configure the Database](#download-mariadb-and-configure-the-database)
-  - [Create User with Replication Grant](#create-user-with-replication-grant)
-  - [Verify the Access of the User](#verify-the-access-of-the-user)
-  - [Set the VMs to Accept the MariaDB Connection](#set-the-vms-to-accept-the-mariadb-connection)
-    - [TF Template Worker Server Data](#tf-template-worker-server-data)
-    - [TF Template Master Server Data](#tf-template-master-server-data)
   - [Set the Nextcloud User and Database](#set-the-nextcloud-user-and-database)
-- [Install and Set GlusterFS](#install-and-set-glusterfs)
 - [Install PHP and Nextcloud](#install-php-and-nextcloud)
 - [Create a Subdomain with DuckDNS](#create-a-subdomain-with-duckdns)
-  - [Worker File for DuckDNS](#worker-file-for-duckdns)
 - [Set Apache](#set-apache)
-- [Access Nextcloud on a Web Browser with the Subdomain](#access-nextcloud-on-a-web-browser-with-the-subdomain)
+- [Access Nextcloud on a Web Browser](#access-nextcloud-on-a-web-browser)
 - [Enable HTTPS](#enable-https)
   - [Install Certbot](#install-certbot)
   - [Set the Certbot with the DNS Domain](#set-the-certbot-with-the-dns-domain)
@@ -104,7 +97,7 @@ Once you've found a 3Node, take note of its node ID. You will need to use this I
 
 ***
 
-# Set the VMs
+# Set the full VM
 
 ## Overview
 
@@ -284,7 +277,7 @@ After deployments, take note of the 3Node's IPv4 address. You will need this add
       sudo ssh-add ~/.ssh/id_rsa
       ```
 
-## Prepare the VM for the Deployment
+## Prepare the full VM
 
 * Update and upgrade the system
   * ```
@@ -460,7 +453,7 @@ The file should look like this, with your own subdomain instead of `subdomain`:
 
 ***
 
-# Access Nextcloud on a Web Browser with the Subdomain
+# Access Nextcloud on a Web Browser
 
 We now access Nextcloud over the public Internet.
 


### PR DESCRIPTION
This PR adds a nextcloud single instance guide to the TF Manual.

The idea to add this guide comes from Robert's feedback on the TF Forum concerning the [redundant nextcloud guide](https://forum.threefold.io/t/threefold-guide-nextcloud-redundant-deployment-on-two-3node-servers/3915/3).

As he said that he uses the redundant guide to deploy a single instance, I thought it'd be nice to have the single instance version available.

Let me know what you think!