### PR TITLE
Added git checkout in workflow

### DIFF
--- a/.github/workflows/manual_update_development.yml
+++ b/.github/workflows/manual_update_development.yml
@@ -17,6 +17,7 @@ jobs:
         port: ${{ secrets.TF_PORT }}
         script: |
           cd websites/www2/info_grid/
+          git checkout development
           git log -1
           git fetch
           git reset --hard origin/development

--- a/.github/workflows/manual_update_development_split.yml
+++ b/.github/workflows/manual_update_development_split.yml
@@ -17,6 +17,7 @@ jobs:
         port: ${{ secrets.TF_PORT }}
         script: |
           cd websites/www3/info_grid
+          git checkout development-split
           git log -1
           git fetch
           git reset --hard origin/development-split

--- a/.github/workflows/manual_update_master.yml
+++ b/.github/workflows/manual_update_master.yml
@@ -17,6 +17,7 @@ jobs:
         port: ${{ secrets.TF_PORT }}
         script: |
           cd websites/info_grid/
+          git checkout master
           git log -1
           git fetch
           git reset --hard origin/master


### PR DESCRIPTION
# Added git checkout <branch> in workflow

I think we should add git checkout <branch> for each branch, to avoid those types of error [see here for an example](https://github.com/threefoldtech/info_grid/actions/runs/5615402448/job/15215611131#step:3:34) (line 33-35). 

Let me know what you think! We can discuss further if needed. This idea was mostly from Thabet in a TG discussion.

@xmonader
