### PR TITLE
added wireguard access guide, adjusted openssh guide

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -180,6 +180,7 @@
       - [SSH with OpenSSH](getstarted/ssh_guide/ssh_openssh.md)
       - [SSH with PuTTY](getstarted/ssh_guide/ssh_putty.md)
       - [SSH with WSL](getstarted/ssh_guide/ssh_wsl.md)
+      - [WireGuard Access](getstarted/ssh_guide/ssh_wireguard.md)
     - [Remote Desktop and GUI](getstarted/remote-desktop_gui/remote-desktop_gui.md)
       - [Cockpit: a Web-based Interface for Servers](getstarted/remote-desktop_gui/cockpit_guide/cockpit_guide.md)
       - [XRDP: an Open-Source Remote Desktop Protocol](getstarted/remote-desktop_gui/xrdp_guide/xrdp_guide.md)

--- a/src/getstarted/ssh_guide/ssh_guide.md
+++ b/src/getstarted/ssh_guide/ssh_guide.md
@@ -7,3 +7,4 @@ SSH is a secure protocol used as the primary means of connecting to Linux server
 - [SSH with OpenSSH](./ssh_openssh.md)
 - [SSH with PuTTY](./ssh_putty.md)
 - [SSH with WSL](./ssh_wsl.md)
+- [WireGuard Access](./ssh_wireguard.md)

--- a/src/getstarted/ssh_guide/ssh_openssh.md
+++ b/src/getstarted/ssh_guide/ssh_openssh.md
@@ -21,7 +21,7 @@
 
 # Introduction
 
-In this Threefold Guide, we show how easy it is to deploy a full virtual machine (VM) and SSH into a 3node with [OpenSSH](https://www.openssh.com/) on Linux, MAC and Windows with both an IPv4 and a Planetary Network connection.
+In this Threefold Guide, we show how easy it is to deploy a full virtual machine (VM) and SSH into a 3node with [OpenSSH](https://www.openssh.com/) on Linux, MAC and Windows with both an IPv4 and a Planetary Network connection. To connect to the 3Node with WireGuard, read [this documentation](./ssh_wireguard.md).
 
 To deploy different workloads, the SSH connection process should be very similar.
 
@@ -32,9 +32,9 @@ If you have any questions, feel free to write a post on the [Threefold Forum](ht
 
 The prerequisites are:
 
-* [Create a Threefold Connect Wallet](https://manual.grid.tf/getstarted/TF_Connect/TF_Connect.html)
-* [Buy TFT](https://manual.grid.tf/getstarted/TF_Token/TF_Token.html)
-* [Create a Threefold Dashboard Account and Transfer TFT](https://manual.grid.tf/getstarted/TF_Dashboard/TF_Dashboard.html)
+* [Create a Threefold Connect Wallet](../TF_Connect/TF_Connect.md)
+* [Buy TFT](../../threefold_token/buy_sell_tft/buy_sell_tft.md)
+* [Create a Threefold Dashboard Account and Transfer TFT](../TF_Dashboard/TF_Dashboard.md)
 
 The main steps for the whole process are the following:
 
@@ -51,12 +51,6 @@ The main steps for the whole process are the following:
 ## Linux
 
 ### SSH into a 3node with IPv4 on Linux
-
-<div class="youtubeVideoWrapper">
-<iframe title="SSH into a 3node with IPv4 on Linux" width="560" height="315" src="https://peertube.hostservice.nl/videos/embed/a049f97c-f366-451c-b9c0-05766b693c77" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
-</div>
-
-***
 
 * To create the SSH key pair, write in the terminal 
   * ```
@@ -99,12 +93,6 @@ The main steps for the whole process are the following:
 ***
 
 ### SSH into a 3node with the Planetary Network on Linux
-
-<div class="youtubeVideoWrapper">
-<iframe title="SSH into a 3node with the Planetary Network on Linux" width="560" height="315" src="https://peertube.hostservice.nl/videos/embed/793b6100-0f0c-4c76-b000-7f85e4ccd998" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
-</div>
-
-***
 
 * To download and connect to the Threefold Planetary Network Connector
   * Download the [.deb file](https://github.com/threefoldtech/planetary_network/releases/tag/v0.3-rc1-Linux)
@@ -157,12 +145,6 @@ The main steps for the whole process are the following:
 
 ### SSH into a 3node with IPv4 on MAC
 
-<div class="youtubeVideoWrapper">
-<iframe title="SSH into a 3node with IPv4 on MAC" width="560" height="315" src="https://peertube.hostservice.nl/videos/embed/1804a327-df69-430d-aef7-ba55f63dfacb" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
-</div>
-
-***
-
 * To create the SSH key pair, in the terminal write
     * ```
       ssh-keygen
@@ -204,12 +186,6 @@ The main steps for the whole process are the following:
 ***
 
 ### SSH into a 3node with the Planetary Network on MAC
-
-<div class="youtubeVideoWrapper">
-<iframe title="SSH into a 3node with the Planetary Network on MAC" width="560" height="315" src="https://peertube.hostservice.nl/videos/embed/0d11f28c-cf21-4fe5-9165-ae4a28f7c331" frameborder="0" allowfullscreen="" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
-</div>
-
-***
 
 * To download and connect to the Threefold Planetary Network Connector
   * Download the [.dmg file](https://github.com/threefoldtech/planetary_network/releases/tag/v0.3-rc1-MacOS)

--- a/src/getstarted/ssh_guide/ssh_wireguard.md
+++ b/src/getstarted/ssh_guide/ssh_wireguard.md
@@ -1,0 +1,123 @@
+<h1> WireGuard Access </h1>
+
+<h2> Table of Contents </h2>
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Deploy a Full VM with WireGuard Access](#deploy-a-full-vm-with-wireguard-access)
+- [Install WireGuard](#install-wireguard)
+- [Set the WireGuard Configurations](#set-the-wireguard-configurations)
+  - [Linux and MAC](#linux-and-mac)
+  - [Windows](#windows)
+- [Test the WireGuard Connection](#test-the-wireguard-connection)
+- [SSH into the 3Node with Wireguard](#ssh-into-the-3node-with-wireguard)
+- [Questions and Feedback](#questions-and-feedback)
+
+***
+
+# Introduction
+
+In this Threefold Guide, we show how to set up [WireGuard](https://www.wireguard.com/) to access a 3Node with an SSH connection.
+
+Note that WireGuard provides the connection to the 3Node. It is up to you to decide which SSH client you want to use. This means that the steps to SSH into a 3Node will be similar to the steps proposed in the guides for [Open-SSH](./ssh_openssh.md), [PuTTy](ssh_putty.md) and [WSL](./ssh_wsl.md). Please refer to [these guides](./ssh_guide.md) if you have any questions concerning the SSH client in specific. The main difference will be that we will connect to the 3Node using a WireGuard connection instead of an IPv4 or a Planetary Network connection.
+
+***
+
+# Prerequisites
+
+* Activated and funded account set up in the [TF Playground](https://playground.grid.tf/)
+  * [Create a Threefold Connect Wallet](../TF_Connect/TF_Connect.md)
+  * [Buy TFT](../../threefold_token/buy_sell_tft/buy_sell_tft.md)
+  * [Create a Threefold Dashboard Account and Transfer TFT](../TF_Dashboard/TF_Dashboard.md)
+* SSH Client of your choice
+  * [Open-SSH](./ssh_openssh.md)
+  * [PuTTy](ssh_putty.md)
+  * [WSL](./ssh_wsl.md)
+
+***
+
+# Deploy a Full VM with WireGuard Access
+
+We show here how to deploy a Full VM with WireGuard access. Note that this process is similar with other types of ThreeFold weblets on the Playground.
+
+* Go to the [ThreeFold Playground](https://playground.grid.tf/)
+* Select the weblet **Full Virtual Machine**
+* Click on **Network**
+* Check **Add WireGuard Access**
+* Select a node to deploy on
+* Click **Deploy**
+
+Once the Full VM is deployed, a window named **Details** will appear. You will need the content of the section **WireGuard Config** to set the WireGuard configurations. Refer to [this section](#set-the-wireguard-configurations) for more information on how to set the WireGuard configurations. Note that the content of **WireGuard IP** will also be needed to [SSH into the Full VM with WireGuard](#ssh-into-the-3node-with-wireguard).
+
+> Note: At anytime, you can open the **Details** window by clicking on the button **Open Details** under **Actions** on the Playground weblet page.
+
+***
+
+# Install WireGuard
+
+To install WireGuard, please refer to the official [WireGuard installation documentation](https://www.wireguard.com/install/).
+
+***
+
+# Set the WireGuard Configurations
+
+When it comes to setting the WireGuard configurations, the steps are the same for Linux and MAC, but differ slightly for Windows.
+
+## Linux and MAC
+
+To set the WireGuard connection on Linux or MAC, you will need to paste the content **WireGuard Config** from the Playground **Details** window to the file `/usr/local/etc/wireguard/wg.conf`.
+
+To do so, simply create a file named `wg.conf` in the directory: `/usr/local/etc/wireguard` and paste the WireGuard configurations:
+
+```
+nano /usr/local/etc/wireguard/wg.conf
+```
+
+Note that you might need superuser ([sudo](https://www.sudo.ws/)) permissions to do so.
+
+Then, to start WireGuard, write the following in the terminal:
+
+```
+wg-quick up wg
+```
+
+If you want to stop the WireGuard service, you can write the following in the terminal:
+
+```
+wg-quick down wg
+```
+
+> Note: If it doesn't work and you already did a WireGuard connection with the same file, write on the terminal `wg-quick down wg`, then `wg-quick up wg`.
+
+## Windows
+
+To set the WireGuard connection on Windows, open the WireGuard GUI app, click on **Add Tunnel** and then **Add empty tunnel**, choose a name for the tunnel and, in the main window, erase the content of the main window and paste the content **WireGuard Config** from the Playground **Details** window. Click **Save** and then click on **Activate**.
+
+***
+  
+
+# Test the WireGuard Connection
+
+As a test, you can ping the virtual IP address of the VM to make sure the WireGuard connection is properly established. Make sure to replace `VM_WireGuard_IP` with the proper WireGuard IP address:
+
+```
+ping -c 2 VM_WireGuard_IP
+```
+
+***
+
+# SSH into the 3Node with Wireguard
+
+To SSH into the 3Node with Wireguard, simply write the following in the terminal with the proper WireGuard IP address (named **WireGuard IP** in the Playground **Details** window):
+
+```
+ssh root@VM_WireGuard_IP
+```
+
+You now have access to the VM over a WireGuard SSH connection.
+
+***
+
+# Questions and Feedback
+
+If you have any questions, let us know by writing a post on the [Threefold Forum](http://forum.threefold.io/) or by reaching out to the [ThreeFold Grid Tester Community](https://t.me/threefoldtesting) on Telegram.

--- a/src/getstarted/ssh_guide/ssh_wireguard.md
+++ b/src/getstarted/ssh_guide/ssh_wireguard.md
@@ -4,22 +4,22 @@
 
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Deploy a Full VM with WireGuard Access](#deploy-a-full-vm-with-wireguard-access)
+- [Deploy a Weblet with WireGuard Access](#deploy-a-weblet-with-wireguard-access)
 - [Install WireGuard](#install-wireguard)
 - [Set the WireGuard Configurations](#set-the-wireguard-configurations)
   - [Linux and MAC](#linux-and-mac)
   - [Windows](#windows)
 - [Test the WireGuard Connection](#test-the-wireguard-connection)
-- [SSH into the 3Node with Wireguard](#ssh-into-the-3node-with-wireguard)
+- [SSH into the Deployment with Wireguard](#ssh-into-the-deployment-with-wireguard)
 - [Questions and Feedback](#questions-and-feedback)
 
 ***
 
 # Introduction
 
-In this Threefold Guide, we show how to set up [WireGuard](https://www.wireguard.com/) to access a 3Node with an SSH connection.
+In this Threefold Guide, we show how to set up [WireGuard](https://www.wireguard.com/) to access a 3Node deployment with an SSH connection. 
 
-Note that WireGuard provides the connection to the 3Node. It is up to you to decide which SSH client you want to use. This means that the steps to SSH into a 3Node will be similar to the steps proposed in the guides for [Open-SSH](./ssh_openssh.md), [PuTTy](ssh_putty.md) and [WSL](./ssh_wsl.md). Please refer to [these guides](./ssh_guide.md) if you have any questions concerning the SSH client in specific. The main difference will be that we will connect to the 3Node using a WireGuard connection instead of an IPv4 or a Planetary Network connection.
+Note that WireGuard provides the connection to the 3Node deployment. It is up to you to decide which SSH client you want to use. This means that the steps to SSH into a 3Node deployment will be similar to the steps proposed in the guides for [Open-SSH](./ssh_openssh.md), [PuTTy](ssh_putty.md) and [WSL](./ssh_wsl.md). Please refer to [this documentation](./ssh_guide.md) if you have any questions concerning SSH clients. The main difference will be that we connect to the 3Node deployment using a WireGuard connection instead of an IPv4 or a Planetary Network connection.
 
 ***
 
@@ -29,27 +29,27 @@ Note that WireGuard provides the connection to the 3Node. It is up to you to dec
   * [Create a Threefold Connect Wallet](../TF_Connect/TF_Connect.md)
   * [Buy TFT](../../threefold_token/buy_sell_tft/buy_sell_tft.md)
   * [Create a Threefold Dashboard Account and Transfer TFT](../TF_Dashboard/TF_Dashboard.md)
-* SSH Client of your choice
+* SSH client of your choice
   * [Open-SSH](./ssh_openssh.md)
   * [PuTTy](ssh_putty.md)
   * [WSL](./ssh_wsl.md)
 
 ***
 
-# Deploy a Full VM with WireGuard Access
+# Deploy a Weblet with WireGuard Access
 
-We show here how to deploy a Full VM with WireGuard access. Note that this process is similar with other types of ThreeFold weblets on the Playground.
+The ThreeFold Playground proposes different [basic environments](../../playground/basic_environments_readme.md) and [ready community solutions](../../playground/ready_community_readme.md) in the form of easy-to-use weblets. For this guide on WireGuard access, we deploy a [Full VM](../../playground/fullVm.md). Note that the whole process is similar with other types of ThreeFold weblets on the Playground.
 
 * Go to the [ThreeFold Playground](https://playground.grid.tf/)
 * Select the weblet **Full Virtual Machine**
 * Click on **Network**
-* Check **Add WireGuard Access**
+  * Check **Add WireGuard Access**
 * Select a node to deploy on
 * Click **Deploy**
 
-Once the Full VM is deployed, a window named **Details** will appear. You will need the content of the section **WireGuard Config** to set the WireGuard configurations. Refer to [this section](#set-the-wireguard-configurations) for more information on how to set the WireGuard configurations. Note that the content of **WireGuard IP** will also be needed to [SSH into the Full VM with WireGuard](#ssh-into-the-3node-with-wireguard).
+Once the Full VM is deployed, a window named **Details** will appear. You will need to take note of the **WireGuard Config** to set the WireGuard configurations and the **WireGuard IP** to SSH into the deployment.
 
-> Note: At anytime, you can open the **Details** window by clicking on the button **Open Details** under **Actions** on the Playground weblet page.
+> Note: At anytime, you can open the **Details** window by clicking on the button **Show Details** under **Actions** on the Playground weblet page.
 
 ***
 
@@ -61,37 +61,39 @@ To install WireGuard, please refer to the official [WireGuard installation docum
 
 # Set the WireGuard Configurations
 
-When it comes to setting the WireGuard configurations, the steps are the same for Linux and MAC, but differ slightly for Windows.
+When it comes to setting the WireGuard configurations, the steps are similar for Linux and MAC, but differ slightly for Windows. For Linux and MAC, we will be using the CLI. For Windows, we will be using the WireGuard GUI app.
 
 ## Linux and MAC
 
-To set the WireGuard connection on Linux or MAC, you will need to paste the content **WireGuard Config** from the Playground **Details** window to the file `/usr/local/etc/wireguard/wg.conf`.
+To set the WireGuard connection on Linux or MAC, create a WireGuard configuration file and run WireGuard via the command line:
 
-To do so, simply create a file named `wg.conf` in the directory: `/usr/local/etc/wireguard` and paste the WireGuard configurations:
+* Copy the content **WireGuard Config** from the Playground **Details** window
+* Paste the content to a file with the extension `.conf` (e.g. **wg.conf**) in the directory `/usr/local/etc/wireguard`
+  * ```
+    nano /usr/local/etc/wireguard/wg.conf
+    ```
+  * Note that you might need superuser permissions (`sudo su`) to do so.
 
-```
-nano /usr/local/etc/wireguard/wg.conf
-```
+* Start WireGuard with the command **wg-quick** and, as a parameter, pass the configuration file without the extension (e.g. *wg.conf -> wg*)
+  * ```
+    wg-quick up wg
+    ```
+* If you want to stop the WireGuard service, you can write the following in the terminal
+  * ```
+    wg-quick down wg
+    ```
 
-Note that you might need superuser ([sudo](https://www.sudo.ws/)) permissions to do so.
-
-Then, to start WireGuard, write the following in the terminal:
-
-```
-wg-quick up wg
-```
-
-If you want to stop the WireGuard service, you can write the following in the terminal:
-
-```
-wg-quick down wg
-```
-
-> Note: If it doesn't work and you already did a WireGuard connection with the same file, write on the terminal `wg-quick down wg`, then `wg-quick up wg`.
+> Note: If it doesn't work and you already did a WireGuard connection with the same file, write on the terminal `wg-quick down wg`, then `wg-quick up wg` to reset the connection with new configurations.
 
 ## Windows
 
-To set the WireGuard connection on Windows, open the WireGuard GUI app, click on **Add Tunnel** and then **Add empty tunnel**, choose a name for the tunnel and, in the main window, erase the content of the main window and paste the content **WireGuard Config** from the Playground **Details** window. Click **Save** and then click on **Activate**.
+To set the WireGuard connection on Windows, add and activate a tunnel with the WireGuard app:
+
+* Open the WireGuard GUI app
+* Click on **Add Tunnel** and then **Add empty tunnel**
+* Choose a name for the tunnel
+* Erase the content of the main window and paste the content **WireGuard Config** from the Playground **Details** window
+* Click **Save** and then click on **Activate**.
 
 ***
   
@@ -100,21 +102,23 @@ To set the WireGuard connection on Windows, open the WireGuard GUI app, click on
 
 As a test, you can ping the virtual IP address of the VM to make sure the WireGuard connection is properly established. Make sure to replace `VM_WireGuard_IP` with the proper WireGuard IP address:
 
-```
-ping -c 2 VM_WireGuard_IP
-```
+* Ping the deployment
+  * ```
+    ping -c 2 VM_WireGuard_IP
+    ```
 
 ***
 
-# SSH into the 3Node with Wireguard
+# SSH into the Deployment with Wireguard
 
-To SSH into the 3Node with Wireguard, simply write the following in the terminal with the proper WireGuard IP address (named **WireGuard IP** in the Playground **Details** window):
+To SSH into the deployment with Wireguard, use the **WireGuard IP** shown in the Playground **Details** window.
 
-```
-ssh root@VM_WireGuard_IP
-```
+* SSH into the deployment
+  * ```
+    ssh root@VM_WireGuard_IP
+    ```
 
-You now have access to the VM over a WireGuard SSH connection.
+You now have access to the deployment over a WireGuard SSH connection.
 
 ***
 

--- a/src/system_administrators/system_administrators.md
+++ b/src/system_administrators/system_administrators.md
@@ -20,6 +20,7 @@ From deployment strategies to monitoring tools, from security best practices to 
     - [SSH with OpenSSH](../getstarted/ssh_guide/ssh_openssh.md)
     - [SSH with PuTTY](../getstarted/ssh_guide/ssh_putty.md)
     - [SSH with WSL](../getstarted/ssh_guide/ssh_wsl.md)
+    - [WireGuard Access](../getstarted/ssh_guide/ssh_wireguard.md)
   - [Remote Desktop and GUI](../getstarted/remote-desktop_gui/remote-desktop_gui.md)
     - [Cockpit: a Web-based Interface for Servers](../getstarted/remote-desktop_gui/cockpit_guide/cockpit_guide.md)
     - [XRDP: an Open-Source Remote Desktop Protocol](../getstarted/remote-desktop_gui/xrdp_guide/xrdp_guide.md)


### PR DESCRIPTION
added wireguard access guide, adjusted openssh guide

This will complement the openssh, putty and wsl guides. It is another method to ssh into a 3node, apart from planetary network and ipv4.

It has been often reported by farmers that it was hard to ssh with planetary network. This wireguard guide should ease the process to ssh into a 3node.