### PR TITLE
adjusted GPU files

### DIFF
--- a/src/dashboard/explorer/explorer_gpu_support.md
+++ b/src/dashboard/explorer/explorer_gpu_support.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-We are quite busy nowadays with integrating GPUs with the TFGrid. We present here a quick update on how things are going with this project. More information will be added to this section soon.
+The TFGrid now supports GPU. Note that to deploy a workload on the TFGrid and use a GPU, you will need to rent the whole 3Node as a dedicated server.
 
 ***
 
@@ -18,11 +18,11 @@ We are quite busy nowadays with integrating GPUs with the TFGrid. We present her
 
 ![GPU support](../img/explorer_gpu.png)
 
-- A new filter for GPU supported node is going to be added
+- A new filter for GPU supported node is now available on the TF Explorer
 - GPU count
 - Filtering capabilities based on the model / device
 
-On the details pages we will be showing the card information and its status (`reserved` or `available`) also the ID that’s needed to be used during deployments is easily accessible and has a copy to clipboard button
+On the details pages is shown the card information and its status (`reserved` or `available`) also the ID that’s needed to be used during deployments is easily accessible and has a copy to clipboard button.
 
 ![GPU details](../img/gpu_details.png)
 
@@ -30,9 +30,7 @@ Here’s an example of how it looks in case of reserved
 
 ![GPU details](../img/gpu_details_reserved.png)
 
-For more information on the ongoing progress, you can have a look at [this pull request](https://github.com/threefoldtech/tfgrid-sdk-ts/pull/706). This PR also includes many helpful videos.
-
-The TF Dashboard is where to reserve the nodes the farmer should be able to set the extra fees on the form and the user also should be able to reserve and get the details of the node (cost including the extrafees, GPU informations). Note that this is currently in progress.
+The TF Dashboard is where to reserve the nodes the farmer should be able to set the extra fees on the form and the user also should be able to reserve and get the details of the node (cost including the extrafees, GPU informations).
 
 ***
 

--- a/src/go/grid3_go_gpu_support.md
+++ b/src/go/grid3_go_gpu_support.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> GPU Support and Go </h1>
 
 <h2> Table of Contents </h2>

--- a/src/go/grid3_go_vm_with_gpu.md
+++ b/src/go/grid3_go_vm_with_gpu.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> Deploy a VM with GPU </h1>
 
 <h2> Table of Contents </h2>

--- a/src/javascript/grid3_javascript_gpu_support.md
+++ b/src/javascript/grid3_javascript_gpu_support.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> GPU Support and JavaScript </h1>
 
 We present here a quick introduction to GPU support with JavaScript. 

--- a/src/terraform/terraform_gpu_support.md
+++ b/src/terraform/terraform_gpu_support.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> GPU Support and Terraform </h1>
 
 <h2> Table of Contents </h2>

--- a/src/tfchain/tfchain.md
+++ b/src/tfchain/tfchain.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> TF Chain <h1>
 
 <h2> Table of Contents </h2>
@@ -18,7 +16,6 @@
 - [Farming Policies](#farming-policies)
 - [Node Connection price](#node-connection-price)
 - [Node Certifiers](#node-certifiers)
-- [GPU Support](#gpu-support)
 
 ***
 
@@ -100,7 +97,3 @@ See [tfchain_dao](/dashboard/dao_voting/dao_voting.md#an-introduction-to-the-dao
 Node certifiers are entities who are allowed to set a node's certification level to `Certified`. The DAO can propose to add / remove entities that can certify nodes. This is usefull for allowing approved resellers of Threefold nodes to mark nodes as Certified. A certified node farms 25% more tokens than `Diy` a node.
 
 See [tfchain_dao](/dashboard/dao_voting/dao_voting.md#an-introduction-to-the-dao-concept) on how the DAO can add/remove node certifiers.
-***
-## GPU Support
-
-On TFChain there will be a small migration to store the information if the node has_gpu/or gpu devices count on the node and the extra price the farmer wants to receive as a fee [ADR Link](https://github.com/threefoldtech/tfchain/blob/development/docs/architecture/0011-dedicated-nodes-extra-fee.md).

--- a/src/weblets/weblets_fullVm.md
+++ b/src/weblets/weblets_fullVm.md
@@ -1,5 +1,3 @@
-> Note: TFGrid GPU Support is only available on Dev Test for the moment.
-
 <h1> Full Virtual Machine </h1>
 
 <h2> Table of Contents </h2>


### PR DESCRIPTION
From this [issue](https://github.com/threefoldtech/info_grid/issues/152), that was on for 3.11 and marked as completed, but it hasn't yet been updated to the Manual.

In short, it's the GPU support info for javascript, terraform, go mostly.

The last commit is to remove the note saying GPU is only on dev net. now GPU is on test and main nets.