### PR TITLE
improved gpu dedicated node docs

### DIFF
--- a/src/dashboard/portal/dashboard_portal_dedicated_nodes.md
+++ b/src/dashboard/portal/dashboard_portal_dedicated_nodes.md
@@ -6,25 +6,27 @@
 - [Description](#description)
 - [Billing \& Pricing](#billing--pricing)
 - [Usage](#usage)
-- [Filter and Reserve a GPU Node](#filter-and-reserve-a-gpu-node)
-  - [Filter Nodes](#filter-nodes)
-  - [Reserve a Node](#reserve-a-node)
+- [GPU Support](#gpu-support)
+  - [Filter and Reserve a GPU Node](#filter-and-reserve-a-gpu-node)
+    - [Filter Nodes](#filter-nodes)
+    - [Reserve a Node](#reserve-a-node)
+  - [GPU Support Links](#gpu-support-links)
 
 ***
 
-## What is a Dedicated Node?
+# What is a Dedicated Node?
 
 Dedicated nodes are 3Nodes that can be reserved and rented entirely by one user. The user can thus reserve an entire node and use it exclusively to deploy solutions. This feature is ideal for users who want to host heavy deployments with the benefits of high reliability and cost effectiveness.
 
 ***
-## Description
+# Description
 
 - Node reserved with deploying a `RentContract` on this node. node can has only one rentContract.
 - When a user create a RentContract against a node, the grid validate that there are no other active contracts on that node on the creation.
 - Once a RentContract is created, the grid can only accept contracts on this node from the tenant.
 - Only workloads from the tenant are accepted
 ***
-## Billing & Pricing
+# Billing & Pricing
 
 - Once a node is rented, there is a fixed charge billed to the tenant regardless of deployed workloads.
 - Any subsequent NodeContract deployed on a node where a rentContract is active (and the same user is creating the nodeContracts) can be excluded from billing (apart from public ip and network usage).
@@ -33,7 +35,7 @@ Dedicated nodes are 3Nodes that can be reserved and rented entirely by one user.
   - a second level discount up to 60% for balance level see [Discount Levels](../../cloud/cloudunits_pricing.md#staking-discount)
 
 ***
-## Usage
+# Usage
 
 - See list of all dedicated node on `Dedicated Nodes` tab on the portal.
 
@@ -63,10 +65,16 @@ Dedicated nodes are 3Nodes that can be reserved and rented entirely by one user.
 
 - Unreserve a node:
   - Simply as reserving but another check will be done to check you don't have any active workloads on the node before unreserving.
+
 ***
+
+# GPU Support
+
+To use a GPU on the TFGrid, users need to rent a dedicated node. Once they have rented a dedicated node equipped with a GPU, users can deploy workloads on their dedicated GPU node.
+
 ## Filter and Reserve a GPU Node
 
-You can filter and reserve a GPU node using the **Dedicated Nodes** section of the **Portal**.
+You can filter and reserve a GPU node using the [Dedicated Nodes section](https://dashboard.grid.tf/portal/account-nodes) of the **Portal**.
 
 ### Filter Nodes
 
@@ -81,4 +89,22 @@ You can filter and reserve a GPU node using the **Dedicated Nodes** section of t
 
 ### Reserve a Node
 
-When you have decided which node to reserve, click on **Reserve** under the column named **Actions**.
+When you have decided which node to reserve, click on **Reserve** under the column named **Actions**. Once you've rented a dedicated node that has a GPU, you can deploy GPU workloads.
+
+## GPU Support Links
+
+The ThreeFold Manual covers many ways to use a GPU node on the TFGrid. A good place to start would be the **Full VM and GPU** documentation. 
+
+Feel free to explore the different possibilities!
+
+* Dashboard and GPU
+  * [ThreeFold Explorer](../explorer/explorer_gpu_support.md)
+  * [GraphQL and GPU](../explorer/explorer_graphql_intro.md#filtering-nodes-with-gpu-devices) 
+* [Javascript Client and GPU](../../javascript/grid3_javascript_gpu_support.md)
+* Go Client and GPU
+  * [GPU Support](../../go/grid3_go_gpu_support.md)
+  * [VM with GPU](../../go/grid3_go_vm_with_gpu.md)
+* [TFGrid CLI and GPU](../../tfgridcmd/grid3_cli_vm.md#deploy-a-vm-with-gpu)
+* [Terraform and GPU](../../terraform/terraform_gpu_support.md)
+* [Full VM and GPU](../../playground/fullVm.md)
+* [Zero-OS API and GPU](../../internals/zos/manual/api.md#gpus)


### PR DESCRIPTION
Added gpu links and info in dedicated node docs. Since only dedicated nodes can have GPU, it seemed like a logical place to put the GPU links.