### PR TITLE
added code of conduct

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -69,6 +69,7 @@
       - [TFGrid v3.0.0 Alpha-2](roadmap/releasenotes/tfgrid_release_3_0_a2.md)
       - [TFGrid v3.0.0](roadmap/releasenotes/tfgrid_release_3_0.md)
   - [FAQ](faq/faq.md)
+  - [Code of Conduct](contribute/code_conduct.md)
   - [Legal](legal/legal.md)
 - [Farmers](farmers/farmers.md)
   - [Build a 3Node](farmers/3node_building/3node_building.md)

--- a/src/contribute/code_conduct.md
+++ b/src/contribute/code_conduct.md
@@ -1,0 +1,82 @@
+<h1> Code of Conduct</h1>
+
+<h2>Table of Contents</h2>
+
+- [Our Ecosystem, Our Home](#our-ecosystem-our-home)
+- [Safety First](#safety-first)
+- [Real Identities](#real-identities)
+- [We're Human](#were-human)
+- [Purpose Over Process, Decentralization is not a purpose by itself](#purpose-over-process-decentralization-is-not-a-purpose-by-itself)
+- [Embrace Positivity and Shared Growth](#embrace-positivity-and-shared-growth)
+- [Content Guidelines](#content-guidelines)
+- [Concentration on Relevance](#concentration-on-relevance)
+- [Right of Admission Reserved](#right-of-admission-reserved)
+- [Role of Moderators](#role-of-moderators)
+- [Disclaimer](#disclaimer)
+
+***
+
+## Our Ecosystem, Our Home
+
+Think of the ThreeFold community and ecosystem as our virtual home. We've opened our doors to guests so we can gather and discuss our shared passion: the decentralized project, ThreeFold. Just as in any home, we have certain expectations about behavior and respect. 
+
+> Note: This applies to the ThreeFold Forum and also to every other parts of TFTech and TFCloud.
+
+## Safety First
+
+Our primary goal is to create a space where everyone feels safe and respected. Personal attacks, harassment, and any form of discrimination will not be tolerated.
+
+## Real Identities
+
+Anonymity can sometimes lead to harmful behavior. To foster trust and accountability in our community, users must not use pseudonyms or fake profiles. Stand by your words with your real identity. 
+
+## We're Human
+
+Remember, we're all human. We'll make mistakes, have our biases, and sometimes get things wrong. 
+This is our forum, and while we strive for fairness and accuracy, we won't always be perfect, and we expect no-one to be.
+
+## Purpose Over Process, Decentralization is not a purpose by itself
+
+While decentralization can have its benefits, it's not our main goal. Our focus is on meaningful discussions, fostering community, and ensuring a respectful environment.
+
+## Embrace Positivity and Shared Growth
+
+We deeply value the energy and spirit our community members bring. We believe in the beauty of what we create together, rooted in the fundamental principle that everyone joins our forum with good intentions. By fostering a culture of sharing — our knowledge, experiences, and aspirations — we create a cycle of giving and receiving. It's this mutual respect and belief in collective growth that propels us forward. We kindly ask all members to contribute with a positive energy, recognizing the potential and goodness in every conversation.
+
+## Content Guidelines
+
+- **Cryptocurrency Discussions**: We are not a cryptocurrency-centric project. Please avoid discussions about token valuations, trading, or any other crypto-related activities. We aim to focus on our core values and mission, rather than market dynamics or speculative behaviors.
+
+- **Spirituality and Religion**: This forum is not a platform for spiritual or religious discussions. While we respect individual beliefs, we request participants to refrain from introducing such topics here.
+  
+- **Legality**: Posts promoting or discussing illegal activities, according to any jurisdiction, are strictly prohibited and will be removed.
+
+## Concentration on Relevance
+
+Our responses are crafted not just for the sake of speaking, but to genuinely address the essence of a forum thread. We prioritize adding content that directly pertains to the topic at hand. Linking to other forum posts is reserved for when it's truly pertinent, and we avoid diverting one thread's focus to champion another.
+
+We love the less is more concept, less words, more impact.
+
+## Right of Admission Reserved
+
+As hosts, we reserve the right to remove anyone or any content from this forum if we believe they are not aligned with the values and guidelines set forth above.
+
+> Thank you for respecting these guidelines and ensuring our forum and virtual spaces remain a constructive and positive experience for all.
+
+## Role of Moderators
+
+Our forum moderators are instrumental in upholding the values outlined above. They, like all of us, are human and may err from time to time. We ask for understanding and appreciation for their efforts and dedication.
+
+Their responsibilities include:
+
+- Enhancing our communication and collaboration.
+- Upholding a positive forum atmosphere.
+- Removing off-topic or malicious posts.
+- Deleting content that contradicts the guidelines stated above.
+- Taking action against participants who consistently breach our code of conduct.
+
+Remember, the ThreeFold forum operates under the umbrella of ThreeFold Cloud, a Dubai-based company. While our primary objective is to champion the ThreeFold Grid—a decentralized technology platform—ThreeFold Cloud also has a commercial mission: to offer professional, well-managed solutions atop the TFGrid.
+
+## Disclaimer
+
+Please note that all efforts are made on a best-effort basis. Neither TFTech nor TFCloud assumes responsibility for any of the code, communication, or information distribution.

--- a/src/general/general.md
+++ b/src/general/general.md
@@ -33,4 +33,5 @@ This book serves as a central hub for gathering general information about ThreeF
 - [ThreeFold Roadmap](../roadmap/roadmap_readme.md)
   - [Release Notes](../roadmap/releasenotes/releasenotes_readme.md)
 - [FAQ](../faq/faq.md)
+- [Code of Conduct](../contribute/code_conduct.md)
 - [Legal](../legal/legal.md)

--- a/src/intro/intro_readme.md
+++ b/src/intro/intro_readme.md
@@ -6,7 +6,7 @@ Welcome to the __ThreeFold Grid Manual__, your comprehensive guide to understand
 
 ## About the ThreeFold Grid
 
-The ThreeFold Grid (TFGrid) is a global, peer-to-peer network that aims to create a more sustainable and equitable digital world. It is built on the principles of decentralization, empowering individuals and organizations to take control of their digital assets, data, and interactions. The ThreeFold Grid is designed to be highly scalable, secure, and environmentally friendly, offering a robust and efficient alternative to traditional centralized cloud and computing services.
+The ThreeFold Grid (TFGrid) is a global, peer-to-peer network that aims to create a more sustainable and equitable digital world. Part of the [ThreeFold](https://threefold.io/) ecosystem, the TFGrid is built on the principles of decentralization, empowering individuals and organizations to take control of their digital assets, data, and interactions. The ThreeFold Grid is designed to be highly scalable, secure, and environmentally friendly, offering a robust and efficient alternative to traditional centralized cloud and computing services.
 
 Within this manual, you will find a wealth of information on how to leverage the capabilities of the ThreeFold Grid. Whether you are an individual user, a farmer, a developer, or a business entity, this manual will guide you through the process of accessing, deploying, and managing resources on the grid.
 


### PR DESCRIPTION
* added code of conduct
* added threefold.io link in intro page of the manual

Currently the code of conduct is available on the tfcloud website: https://threefoldfoundation.github.io/info_cloud_production/tfcloud/community/code_conduct.html

We publish the code of conduct on the manual. We will be able to make a clear link on the TF Forum leading to the code of conduct. This will ensure everyone from the community is on the same page when interacting with one another.