### PR TITLE
improved terraform installation section

### DIFF
--- a/src/computer_it_basics/cli_scripts_basics.md
+++ b/src/computer_it_basics/cli_scripts_basics.md
@@ -61,6 +61,8 @@
   - [Count lines in files given as arguments](#count-lines-in-files-given-as-arguments)
   - [Find path of a file](#find-path-of-a-file)
   - [Print how many arguments are passed in a script](#print-how-many-arguments-are-passed-in-a-script)
+- [Linux](#linux)
+  - [Install Terraform](#install-terraform)
 - [MAC](#mac)
   - [Enable remote login on MAC](#enable-remote-login-on-mac)
   - [Find Other storage on MAC](#find-other-storage-on-mac)
@@ -1131,6 +1133,24 @@ You can use the following template to add arguments when running a script:
     ```
 ***
 
+## Linux
+
+### Install Terraform
+
+Here are the steps to install Terraform on Linux based on the [Terraform documentation](https://developer.hashicorp.com/terraform/downloads). 
+
+```
+wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+```
+```
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+```
+```
+sudo apt update && sudo apt install terraform
+```
+
+Note that the Terraform documentation also covers other methods to install Terraform on Linux.
+
 ## MAC
 
 ### Enable remote login on MAC
@@ -1181,19 +1201,19 @@ To install Chocolatey on Windows, we follow the [official Chocolatey website](ht
     * ```
       Set-ExecutionPolicy AllSigned
       ```
-* Install Choco
+* Install Chocolatey
   * ```
     Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
     ```
-* Note: You might need to restart PowerShell to use Choco
+* Note: You might need to restart PowerShell to use Chocolatey
 
 ***
 
 ### Install Terraform with Chocolatey
 
-Once you've installed Choco on Windows, installing Terraform is as simple as can be:
+Once you've installed Chocolatey on Windows, installing Terraform is as simple as can be:
 
-* Install Terraform with Choco
+* Install Terraform with Chocolatey
   * ```
     choco install terraform
     ```

--- a/src/computer_it_basics/cli_scripts_basics.md
+++ b/src/computer_it_basics/cli_scripts_basics.md
@@ -9,6 +9,7 @@
   - [Install Go](#install-go)
   - [Install Brew](#install-brew)
   - [Brew basic commands](#brew-basic-commands)
+  - [Install Terraform with Brew](#install-terraform-with-brew)
   - [Yarn basic commands](#yarn-basic-commands)
   - [Set default terminal](#set-default-terminal)
   - [See the current path](#see-the-current-path)
@@ -65,6 +66,8 @@
   - [Find Other storage on MAC](#find-other-storage-on-mac)
   - [Sort files by size and extension on MAC](#sort-files-by-size-and-extension-on-mac)
 - [Windows](#windows)
+  - [Install Chocolatey](#install-chocolatey)
+  - [Install Terraform with Chocolatey](#install-terraform-with-chocolatey)
   - [Find the product key](#find-the-product-key)
   - [Find Windows license type](#find-windows-license-type)
 - [References](#references)
@@ -158,6 +161,21 @@ Follow those steps to install [Brew](https://brew.sh/)
 * [Uninstall Brew](https://github.com/homebrew/install#uninstall-homebrew)
   * ```
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
+    ```
+
+***
+
+### Install Terraform with Brew
+
+Installing Terraform with Brew is very simple by following the [Terraform documentation](https://developer.hashicorp.com/terraform/downloads).
+
+* Compile HashiCorp software on Homebrew's infrastructure
+  * ```
+    brew tap hashicorp/tap
+    ```
+* Install Terraform
+  * ```
+    brew install hashicorp/tap/terraform
     ```
 
 ***
@@ -1150,6 +1168,38 @@ You can use the following template to add arguments when running a script:
 
 ## Windows
 
+### Install Chocolatey
+
+To install Chocolatey on Windows, we follow the [official Chocolatey website](https://chocolatey.org/install) instructions.
+
+* Run PowerShell as Administrator
+* Check if **Get-ExecutionPolicy** is restricted
+  * ```
+    Get-ExecutionPolicy
+    ```
+  * If it is restricted, run the following command:
+    * ```
+      Set-ExecutionPolicy AllSigned
+      ```
+* Install Choco
+  * ```
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    ```
+* Note: You might need to restart PowerShell to use Choco
+
+***
+
+### Install Terraform with Chocolatey
+
+Once you've installed Choco on Windows, installing Terraform is as simple as can be:
+
+* Install Terraform with Choco
+  * ```
+    choco install terraform
+    ```
+
+***
+
 ### Find the product key
 
 Write the following in **Command Prompt** (run as administrator):
@@ -1157,6 +1207,8 @@ Write the following in **Command Prompt** (run as administrator):
 ```
 wmic path SoftwareLicensingService get OA3xOriginalProductKey
 ```
+
+***
 
 ### Find Windows license type
 

--- a/src/terraform/advanced/terraform_nextcloud_redundant.md
+++ b/src/terraform/advanced/terraform_nextcloud_redundant.md
@@ -77,7 +77,7 @@ To get an overview of the whole process, we present the main steps:
 
 # Prerequisites
 
-* [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+* [Install Terraform](../terraform_install.md)
 * [Install Wireguard](https://www.wireguard.com/install/)
 
 You need to download and install properly Terraform and Wireguard on your local computer. Simply follow the documentation depending on your operating system (Linux, MAC and Windows).

--- a/src/terraform/advanced/terraform_nextcloud_single.md
+++ b/src/terraform/advanced/terraform_nextcloud_single.md
@@ -63,7 +63,7 @@ To get an overview of the whole process, we present the main steps:
 
 # Prerequisites
 
-* [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+- [Install Terraform](../terraform_install.md)
 
 You need to download and install properly Terraform on your local computer. Simply follow the documentation depending on your operating system (Linux, MAC and Windows).
 

--- a/src/terraform/advanced/terraform_wireguard_ssh.md
+++ b/src/terraform/advanced/terraform_wireguard_ssh.md
@@ -23,7 +23,7 @@ In this ThreeFold Guide, we show how simple it is to deploy a micro VM on the Th
 
 ## Prerequisites
 
-* [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+* [Install Terraform](../terraform_install.md)
 * [Install Wireguard](https://www.wireguard.com/install/)
 
 You need to download and install properly Terraform and Wireguard on your local computer. Simply follow the linked documentation depending on your operating system (Linux, MAC and Windows).

--- a/src/terraform/advanced/terraform_wireguard_vpn.md
+++ b/src/terraform/advanced/terraform_wireguard_vpn.md
@@ -24,8 +24,8 @@ Note that this concept can be extended with more than two micro VMs. Once you un
 ***
 ## Prerequisites
 
-* [Download Terraform](https://developer.hashicorp.com/terraform/downloads)
-* [Download Wireguard](https://www.wireguard.com/install/)
+* [Install Terraform](../terraform_install.md)
+* [Install Wireguard](https://www.wireguard.com/install/)
 
 You need to download and install properly Terraform and Wireguard on your local computer. Simply follow the linked documentation depending on your operating system (Linux, MAC and Windows).
 

--- a/src/terraform/resources/terraform_qsfs_on_full_vm.md
+++ b/src/terraform/resources/terraform_qsfs_on_full_vm.md
@@ -25,7 +25,7 @@ The main goal of this guide is to show you all the necessary steps to deploy a F
 
 ## Prerequisites
 
-* [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+- [Install Terraform](../terraform_install.md)
 
 You need to download and install properly Terraform. Simply follow the documentation depending on your operating system (Linux, MAC and Windows).
 

--- a/src/terraform/resources/terraform_qsfs_on_microvm.md
+++ b/src/terraform/resources/terraform_qsfs_on_microvm.md
@@ -25,7 +25,7 @@ In this ThreeFold Guide, we will learn how to deploy a Quantum Safe File System 
 
 In this guide, we will be using Terraform to deploy a QSFS workload on a micro VM that runs on the TFGrid. Make sure to have the latest Terraform version.
 
-* [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+- [Install Terraform](../terraform_install.md)
 
 ***
 

--- a/src/terraform/terraform_full_vm.md
+++ b/src/terraform/terraform_full_vm.md
@@ -44,7 +44,7 @@ Once this is done, initialize and apply Terraform to deploy your workload, then 
 
 ## Prerequisites
 
-- [Install Terraform](https://developer.hashicorp.com/terraform/downloads)
+- [Install Terraform](./terraform_install.md)
 
 You need to download and install properly Terraform. Simply follow the documentation depending on your operating system (Linux, MAC and Windows).
 

--- a/src/terraform/terraform_install.md
+++ b/src/terraform/terraform_install.md
@@ -4,7 +4,8 @@
 
 - [Introduction](#introduction)
 - [Install Terraform](#install-terraform)
-  - [Install Terraform on MAC and Linux](#install-terraform-on-mac-and-linux)
+  - [Install Terraform on Linux](#install-terraform-on-linux)
+  - [Install Terraform on MAC](#install-terraform-on-mac)
   - [Install Terraform on Windows](#install-terraform-on-windows)
 - [ThreeFold Terraform Plugin](#threefold-terraform-plugin)
 - [Questions and Feedback](#questions-and-feedback)
@@ -21,18 +22,22 @@ You can get Terraform from the Terraform website [download page](https://www.ter
 
 We cover here the basic steps for Linux, MAC and Windows for convenience. Refer to the official Terraform documentation if needed.
 
-### Install Terraform on MAC and Linux
+### Install Terraform on Linux
 
-To install Terraform on MAC and Linux, a quick way is to first install Brew and then install Terraform.
+To install Terraform on Linux, we follow the official [Terraform documentation](https://developer.hashicorp.com/terraform/downloads). 
+
+* [Install Terraform on Linux](../computer_it_basics/cli_scripts_basics.md#install-terraform)
+
+### Install Terraform on MAC
+
+To install Terraform on MAC, install Brew and then install Terraform.
 
 * [Install Brew](../computer_it_basics/cli_scripts_basics.md#install-brew)
 * [Install Terraform with Brew](../computer_it_basics/cli_scripts_basics.md#install-terraform-with-brew)
 
-For other methods of installation with Linux, you can also refer to the [Terraform documentation](https://developer.hashicorp.com/terraform/downloads).
-
 ### Install Terraform on Windows
 
-To install Terraform on Windows, a quick way is to first install Chocolatey (Choco) and then install Terraform.
+To install Terraform on Windows, a quick way is to first install Chocolatey and then install Terraform.
 
 * [Install Chocolatey](../computer_it_basics/cli_scripts_basics.md#install-chocolatey)
 * [Install Terraform with Chocolatey](../computer_it_basics/cli_scripts_basics.md#install-terraform-with-chocolatey)

--- a/src/terraform/terraform_install.md
+++ b/src/terraform/terraform_install.md
@@ -1,9 +1,48 @@
-![ ](./img//terraform_install.png)
+<h1> Installing Terraform</h1>
 
-### Terraform Install
+<h2> Table of Contents </h2>
 
-Please note that for now our [Terraform plugin](https://github.com/threefoldtech/terraform-provider-grid) is supported on Linux and MacOS. Windows
+- [Introduction](#introduction)
+- [Install Terraform](#install-terraform)
+  - [Install Terraform on MAC and Linux](#install-terraform-on-mac-and-linux)
+  - [Install Terraform on Windows](#install-terraform-on-windows)
+- [ThreeFold Terraform Plugin](#threefold-terraform-plugin)
+- [Questions and Feedback](#questions-and-feedback)
 
-Get Terraform from the [download page](https://www.terraform.io/downloads.html) on the official site, or install using you system's package manager. please check the [installation manual](https://learn.hashicorp.com/tutorials/terraform/install-cli)
+***
+
+## Introduction
+
+There are many ways to install Terraform depending on your operating system. Terraform is available for Linux, MAC and Windows.
+
+## Install Terraform
+
+You can get Terraform from the Terraform website [download page](https://www.terraform.io/downloads.html). You can also install it using your system package manager. The Terraform [installation manual](https://learn.hashicorp.com/tutorials/terraform/install-cli) contains the essential information for a proper installation.
+
+We cover here the basic steps for Linux, MAC and Windows for convenience. Refer to the official Terraform documentation if needed.
+
+### Install Terraform on MAC and Linux
+
+To install Terraform on MAC and Linux, a quick way is to first install Brew and then install Terraform.
+
+* [Install Brew](../computer_it_basics/cli_scripts_basics.md#install-brew)
+* [Install Terraform with Brew](../computer_it_basics/cli_scripts_basics.md#install-terraform-with-brew)
+
+For other methods of installation with Linux, you can also refer to the [Terraform documentation](https://developer.hashicorp.com/terraform/downloads).
+
+### Install Terraform on Windows
+
+To install Terraform on Windows, a quick way is to first install Chocolatey (Choco) and then install Terraform.
+
+* [Install Chocolatey](../computer_it_basics/cli_scripts_basics.md#install-chocolatey)
+* [Install Terraform with Chocolatey](../computer_it_basics/cli_scripts_basics.md#install-terraform-with-chocolatey)
+
+## ThreeFold Terraform Plugin
+
+The ThreeFold [Terraform plugin](https://github.com/threefoldtech/terraform-provider-grid) is supported on Linux, MAC and Windows.
 
 There's no need to specifically install the ThreeFold Terraform plugin. Terraform will automatically load it from an online directory according to instruction within the deployment file.
+
+## Questions and Feedback
+
+If you have any questions, let us know by writing a post on the [Threefold Forum](http://forum.threefold.io/) or by reaching out to the [ThreeFold Grid Tester Community](https://t.me/threefoldtesting) on Telegram.


### PR DESCRIPTION
Based on discussions with the TF Support team, we decided to improve the Terraform installation section.

* simple installation process for windows, mac and linux
* linked the Install Terraform URL in terraform guides to this updated section, instead of the general Terraform documentation

This should ease the process of working with Terraform.

Note: instead of rewriting the same info on different pages, we link the users to the CLI computer basic IT page. 