### PR TITLE
Link Checker

### DIFF
--- a/.github/workflows/manual_update_development.yml
+++ b/.github/workflows/manual_update_development.yml
@@ -4,7 +4,7 @@ on:
     branches: [ development ]
 
 jobs:
-  job_one:
+  deploy:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
@@ -23,19 +23,19 @@ jobs:
           git reset --hard origin/development
           mdbook build -d docs
 
-  job_two:
-    needs: job_one
+  wait:
+    needs: deploy
     name: Wait for Website Update
     runs-on: ubuntu-latest
     steps:
-    - name: Sleep and Run
+    - name: Wait Period
       id: wait-deploy
       run: |
         echo "Sleeping for 30"
         sleep 30
         
-  job_three:
-    needs: [job_one, job_two]
+  checklinks:
+    needs: wait
     name: Check for Broken Links
     runs-on: ubuntu-latest
     steps:
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www2.manual.grid.tf -w 404'
+          args: 'https://www2.manual.grid.tf -e 404 -w all'

--- a/.github/workflows/manual_update_development.yml
+++ b/.github/workflows/manual_update_development.yml
@@ -22,3 +22,25 @@ jobs:
           git fetch
           git reset --hard origin/development
           mdbook build -d docs
+
+  job_two:
+    needs: job_one
+    name: Wait for Website Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Sleep and Run
+      id: wait-deploy
+      run: |
+        echo "Sleeping for 30"
+        sleep 30
+        
+  job_three:
+    needs: [job_one, job_two]
+    name: Check for Broken Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links
+        id: link-report
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www2.manual.grid.tf -w 404'

--- a/.github/workflows/manual_update_development.yml
+++ b/.github/workflows/manual_update_development.yml
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www2.manual.grid.tf -e 404 -w all'
+          args: 'https://www2.manual.grid.tf -e 404 500 501 502 503 504 -w all'

--- a/.github/workflows/manual_update_development_split.yml
+++ b/.github/workflows/manual_update_development_split.yml
@@ -4,7 +4,7 @@ on:
     branches: [ development-split ]
 
 jobs:
-  job_one:
+  deploy:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
@@ -23,19 +23,19 @@ jobs:
           git reset --hard origin/development-split
           mdbook build -d docs
           
-  job_two:
-    needs: job_one
+  wait:
+    needs: deploy
     name: Wait for Website Update
     runs-on: ubuntu-latest
     steps:
-    - name: Sleep and Run
+    - name: Wait Period
       id: wait-deploy
       run: |
         echo "Sleeping for 30"
         sleep 30
         
-  job_three:
-    needs: [job_one, job_two]
+  checklinks:
+    needs: wait
     name: Check for Broken Links
     runs-on: ubuntu-latest
     steps:
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www3.manual.grid.tf -w 404'
+          args: 'https://www3.manual.grid.tf -e 404 -w all'

--- a/.github/workflows/manual_update_development_split.yml
+++ b/.github/workflows/manual_update_development_split.yml
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www3.manual.grid.tf -e 404 -w all'
+          args: 'https://www3.manual.grid.tf -e 404 500 501 502 503 504 -w all'

--- a/.github/workflows/manual_update_development_split.yml
+++ b/.github/workflows/manual_update_development_split.yml
@@ -22,3 +22,25 @@ jobs:
           git fetch
           git reset --hard origin/development-split
           mdbook build -d docs
+          
+  job_two:
+    needs: job_one
+    name: Wait for Website Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Sleep and Run
+      id: wait-deploy
+      run: |
+        echo "Sleeping for 30"
+        sleep 30
+        
+  job_three:
+    needs: [job_one, job_two]
+    name: Check for Broken Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links
+        id: link-report
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www3.manual.grid.tf -w 404'

--- a/.github/workflows/manual_update_master.yml
+++ b/.github/workflows/manual_update_master.yml
@@ -4,7 +4,7 @@ on:
     branches: [ master ]
 
 jobs:
-  job_one:
+  deploy:
     name: Deploy
     runs-on: ubuntu-latest
     steps:
@@ -23,19 +23,19 @@ jobs:
           git reset --hard origin/master
           mdbook build -d docs
 
-  job_two:
-    needs: job_one
+  wait:
+    needs: deploy
     name: Wait for Website Update
     runs-on: ubuntu-latest
     steps:
-    - name: Sleep and Run
+    - name: Wait Period
       id: wait-deploy
       run: |
         echo "Sleeping for 30"
         sleep 30
         
-  job_three:
-    needs: [job_one, job_two]
+  checklinks:
+    needs: wait
     name: Check for Broken Links
     runs-on: ubuntu-latest
     steps:
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www.manual.grid.tf -w 404'
+          args: 'https://www.manual.grid.tf -e 404 -w all'

--- a/.github/workflows/manual_update_master.yml
+++ b/.github/workflows/manual_update_master.yml
@@ -43,4 +43,4 @@ jobs:
         id: link-report
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www.manual.grid.tf -e 404 -w all'
+          args: 'https://www.manual.grid.tf -e 404 500 501 502 503 504 -w all'

--- a/.github/workflows/manual_update_master.yml
+++ b/.github/workflows/manual_update_master.yml
@@ -22,3 +22,25 @@ jobs:
           git fetch
           git reset --hard origin/master
           mdbook build -d docs
+
+  job_two:
+    needs: job_one
+    name: Wait for Website Update
+    runs-on: ubuntu-latest
+    steps:
+    - name: Sleep and Run
+      id: wait-deploy
+      run: |
+        echo "Sleeping for 30"
+        sleep 30
+        
+  job_three:
+    needs: [job_one, job_two]
+    name: Check for Broken Links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links
+        id: link-report
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www.manual.grid.tf -w 404'

--- a/.github/workflows/manual_weekly_link_check.yml
+++ b/.github/workflows/manual_weekly_link_check.yml
@@ -12,7 +12,7 @@ jobs:
         id: link-report www
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www.manual.grid.tf -e 404 -w all'
+          args: 'https://www.manual.grid.tf -e 404 500 501 502 503 504 -w all'
 
   checkwww2:
     name: Check for Broken Links on www2
@@ -22,7 +22,7 @@ jobs:
         id: link-report www2
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www2.manual.grid.tf -e 404 -w all'
+          args: 'https://www2.manual.grid.tf -e 404 500 501 502 503 504 -w all'
         
   checkwww3:
     name: Check for Broken Links on www3
@@ -32,4 +32,4 @@ jobs:
         id: link-report www3
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www3.manual.grid.tf -e 404 -w all'
+          args: 'https://www3.manual.grid.tf -e 404 500 501 502 503 504 -w all'

--- a/.github/workflows/manual_weekly_link_check.yml
+++ b/.github/workflows/manual_weekly_link_check.yml
@@ -1,0 +1,37 @@
+name: Weekly Link Check
+on:
+  schedule:
+    - cron: '0 6 * * 5'
+
+jobs:
+  job_one:
+    name: Check for Broken Links on www
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links on www
+        id: link-report www
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www.manual.grid.tf -w 404'
+
+  job_two:
+    needs: job_one
+    name: Check for Broken Links on www2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links
+        id: link-report www2
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www2.manual.grid.tf -w 404'
+        
+  job_three:
+    needs: [job_one, job_two]
+    name: Check for Broken Links on www3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Broken Links
+        id: link-report www3
+        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
+        with:
+          args: 'https://www3.manual.grid.tf -w 404'

--- a/.github/workflows/manual_weekly_link_check.yml
+++ b/.github/workflows/manual_weekly_link_check.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 6 * * 5'
 
 jobs:
-  job_one:
+  checkwww:
     name: Check for Broken Links on www
     runs-on: ubuntu-latest
     steps:
@@ -12,10 +12,9 @@ jobs:
         id: link-report www
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www.manual.grid.tf -w 404'
+          args: 'https://www.manual.grid.tf -e 404 -w all'
 
-  job_two:
-    needs: job_one
+  checkwww2:
     name: Check for Broken Links on www2
     runs-on: ubuntu-latest
     steps:
@@ -23,10 +22,9 @@ jobs:
         id: link-report www2
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www2.manual.grid.tf -w 404'
+          args: 'https://www2.manual.grid.tf -e 404 -w all'
         
-  job_three:
-    needs: [job_one, job_two]
+  checkwww3:
     name: Check for Broken Links on www3
     runs-on: ubuntu-latest
     steps:
@@ -34,4 +32,4 @@ jobs:
         id: link-report www3
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
-          args: 'https://www3.manual.grid.tf -w 404'
+          args: 'https://www3.manual.grid.tf -e 404 -w all'


### PR DESCRIPTION
# Link Checker for the TF Manual

As an answer to [this issue](https://github.com/threefoldtech/info_grid/issues/233), @scottyeager and I worked on a [link checker](https://github.com/threefoldfoundation/website-link-checker).

## How It Works

This PR proposes the following:

* weekly link check of the 3 main branches: main, development and development-split.
   * the weekly link check runs at 6 AM (UTC) on Friday, the day of the week where most of the dev team is usually not working.
* link check on push for all 3 branches mentioned above

## Notes

* In all cases, we check for 404 errors on all the manual, and only display the errors as warnings. So the code exit with exit(0)
  * We could set the link checker to give errors and exit with exit(1) for 404. I start with warnings instead of errors to see how it goes. We can adjust in the future, and also query for more error types. We can discuss this if needed.
* Once it's going well (and we cleaned all the current errors, [see this PR](https://github.com/threefoldtech/info_grid/pull/300)), we can set errors instead of warnings and thus receive weekly report by email if a link isn't working anymore. 
* We set weekly checks and not only on **push**, since URLs outside of the manual can change (e.g. presearch docs changes a link, so we must adjust it on the manual).

## Future Use Cases

Once we are satisfied with the link checker, we can implement it on all other mdbooks and threefold websites, as it can be used for any dynamic and static websites, that are online.