### PR TITLE
added cloudconsole docs in playground

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -302,6 +302,7 @@
       - [Taiga](playground/taiga.md)
       - [WordPress](playground/wordpress.md)
       - [Umbrel](playground/umbrel.md)
+    - [Cloud Console](playground/cloud_console.md)
 <!--  - [Mastodon](tf_mastodon/tf_mastodon_readme.md) 
     - [Deploy Mastodon](tf_mastodon/tf_mastodon_deploy.md)
     - [Mastodon FAQ](tf_mastodon/tf_mastodon_faq.md)-->

--- a/src/playground/cloud_console.md
+++ b/src/playground/cloud_console.md
@@ -1,0 +1,33 @@
+<h1>Cloud Console</h1>
+
+<h2>Table of Contents</h2>
+
+- [Introduction](#introduction)
+- [Port Details](#port-details)
+- [Playground Setup](#playground-setup)
+
+***
+
+## Introduction
+
+[Cloud console](https://github.com/threefoldtech/cloud-console) is a tool to view machine logging and interact with the machine you have deployed on the TFGrid. It is a small application intended to provide a web-based terminal for virtual machines, who make a serial device or virtio-console available over a pseudoterminal (**pty**). Although primarily intended to be used with cloud-hypervisor 1, any VM which exposes a pty (or any application which exposes a pty for that matter) should be compatible.
+
+## Port Details
+
+There is a simple way to know the Console port for a TFGrid deployment with WireGuard.
+
+- Cloud console always runs on the IP address of the machine private network.
+- The port number always equals to `20000 + last octet` of a machine private IP address.
+  - For example, if the machine IP is `10.20.2.2/24`, with `2` as the last octet,
+    - `cloud-console` is running on `10.20.2.1:20002`.
+
+## Playground Setup
+
+You can easily enable Cloud console on the ThreeFold Playground.
+
+- On the Playground deployment page, enable the toggle button **Cloud console**.
+  - This will automatically enable WireGuard if it isn't enabled yet.
+- After deployment, set your [WireGuard connection](../getstarted/ssh_guide/ssh_wireguard.md).
+- On a browser, go to the Cloud console URL.
+  - For example, with the WireGuard IP 10.20.2.4, the Cloud console address would be:
+    - `10.20.2.1:20004`

--- a/src/playground/home.md
+++ b/src/playground/home.md
@@ -42,6 +42,8 @@ The backend for the weblets is introduced with the [Javascript Client](../javasc
   - [Wordpress](./wordpress.md)
   - [Umbrel](./umbrel.md)
 
+- [Cloud Console](./cloud_console.md)
+
 ## Advantages
 
 - It is a non-code easy way to deploy a whole solution on the TFGrid.

--- a/src/system_administrators/system_administrators.md
+++ b/src/system_administrators/system_administrators.md
@@ -121,6 +121,7 @@ From deployment strategies to monitoring tools, from security best practices to 
     - [Taiga](../playground/taiga.md)
     - [WordPress](../playground/wordpress.md)
     - [Umbrel](../playground/umbrel.md)
+  - [Cloud Console](../playground/cloud_console.md)
 <!-- - [Mastodon](../tf_mastodon/tf_mastodon_readme.md)
   - [Deploy Mastodon](../tf_mastodon/tf_mastodon_deploy.md)
   - [Mastodon FAQ](../tf_mastodon/tf_mastodon_faq.md) -->


### PR DESCRIPTION
* as an answer to issue #182 
* added cloud console docs in playground
* the content is based on the information from the issue discussion itself and [this documentation](https://github.com/threefoldtech/zos/blob/ded4029c32613dcd9e03d524f5d9007928b0a566/docs/manual/zmachine/cloud-console.md?plain=1#L3)