### PR TITLE
updated solution provider

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -186,7 +186,7 @@
     - [Introduction](tfchain/introduction.md)
     - [Farming Policies](tfchain/farming_policies.md)
     - [External Service Contract](tfchain/tfchain_external_service_contract.md)
-    - [Become a Solution Provider](tfchain/tfchain_solution_provider.md)
+    - [Solution Provider](tfchain/tfchain_solution_provider.md)
   - [Grid Proxy](proxy/proxy_readme.md)
     - [Introducing Grid Proxy](proxy/proxy.md)
     - [Setup](proxy/setup.md)

--- a/src/developers/developers.md
+++ b/src/developers/developers.md
@@ -42,7 +42,7 @@ Whether you're interested in decentralized cloud computing, blockchain integrati
   - [Introduction](../tfchain/introduction.md)
   - [Farming Policies](../tfchain/farming_policies.md)
   - [External Service Contract](../tfchain/tfchain_external_service_contract.md)
-  - [Become a Solution Provider](../tfchain/tfchain_solution_provider.md)
+  - [Solution Provider](../tfchain/tfchain_solution_provider.md)
 - [Grid Proxy](../proxy/proxy_readme.md)
   - [Introducing Grid Proxy](../proxy/proxy.md)
   - [Setup](../proxy/setup.md)

--- a/src/tfchain/tfchain_solution_provider.md
+++ b/src/tfchain/tfchain_solution_provider.md
@@ -1,4 +1,6 @@
-# Solution provider
+# Solution Provider
+
+> Note: While the solution provider program is still active, the plan is to discontinue the program in the near future. We will update the manual as we get more information. We currently do not accept new solution providers.
 
 A "solution" is something running on the grid, created by a community member. This can be brought forward to the council, who can vote on it to recognize it as a solution. On contract creation, a recognized solution can be referenced, in which case part of the payment goes toward the address coupled to the solution. On chain a solution looks as follows:
 

--- a/src/wiki/tfgrid/farming/proof_of_utilization.md
+++ b/src/wiki/tfgrid/farming/proof_of_utilization.md
@@ -24,23 +24,23 @@ Every hour, the utilization is recorded in TFChain and the user is charged for t
 | Percentage | Description                            | Remark                                                                   |
 | ---------- | -------------------------------------- | ------------------------------------------------------------------------ |
 | 35% | TFT burning            | A mechanism used to maintain scarcity in the TFT economy.  |
-| 10% | ThreeFold Foundation   | Funds allocated to promote and grow the ThreeFold Grid.    |
-| 5%  | Validator Staking Pool | Rewards farmers that run TFChain 3.0 validator nodes.      |
+| 15% | ThreeFold Foundation   | Funds allocated to promote and grow the ThreeFold Grid.    |
 | 50% | Solution providers & sales channel | managed by [ThreeFold DAO](../../dao/tfdao.md).             |
+
+> Note: While the solution provider program is still active, the plan is to discontinue the program in the near future. We will update the manual as we get more information. We currently do not accept new solution providers.
 
 ## ThreeFold DAO rules in Relation To Proof-of-Utilization
 
 ### TFGrid Capacity Utilization
 
 - Each solution provider and sales channel gets registered in TFChain and as such the distribution can be defined and calculated at billing time.
-- For billing purposes, ThreeFold DAO will check if it is from a known sales channel or solution provider. If yes, then the billing smart contract code will know how to distribute the TFTs. If the channel of solution provider is not known, then the 50% will go to a DAO owned Community Grant Wallet.
+- For billing purposes, ThreeFold DAO will check if it is from a known sales channel or solution provider. If yes, then the billing smart contract code will know how to distribute the TFTs. If the channel of solution provider is not known, then the 50% will go to the ThreeFold Foundation.
 - For Certified Farming, [ThreeFold Tech](../../threefold_tech.md) can define the solution & sales channel parameters, these are channels as provided by ThreeFold Tech.
 - Burning can be lowered to 25% if too many tokens would be burned, ThreeFold DAO consensus needs to be achieved.
 
 ### Other Ways TFT are required
 
 - Anyone building solutions on top of the TFGrid can use TFT as a currency to charge for the added value they provide, this gives an extra huge requirement for TFT.
-- People also need TFT for staking (locking into) their Validators, validators secure the blockchain and give a good reward for the people who run the validators, this can be upto 50% of the TFT supply.
 - Some will use TFT as a store or exchange of value. Like money, because TFT is a valuable commodity, it could be a more reliable alternative to other digital currencies like BTC. The hoarding of TFT means that TFT are not available to be used on the TF Grid.
 
 

--- a/src/wiki/tfgrid/farming/proof_of_utilization.md
+++ b/src/wiki/tfgrid/farming/proof_of_utilization.md
@@ -24,7 +24,8 @@ Every hour, the utilization is recorded in TFChain and the user is charged for t
 | Percentage | Description                            | Remark                                                                   |
 | ---------- | -------------------------------------- | ------------------------------------------------------------------------ |
 | 35% | TFT burning            | A mechanism used to maintain scarcity in the TFT economy.  |
-| 15% | ThreeFold Foundation   | Funds allocated to promote and grow the ThreeFold Grid.    |
+| 10% | ThreeFold Foundation   | Funds allocated to promote and grow the ThreeFold Grid.    |
+| 5%  | Validator Staking Pool | Rewards farmers that run TFChain 3.0 validator nodes.      |
 | 50% | Solution providers & sales channel | managed by [ThreeFold DAO](../../dao/tfdao.md).             |
 
 > Note: While the solution provider program is still active, the plan is to discontinue the program in the near future. We will update the manual as we get more information. We currently do not accept new solution providers.


### PR DESCRIPTION
# Related Issue

This is to answer issue #359 

Instead of completely removing the solution provider, we include a note that it is not possible to become a new solution provider.

We will be able to update or delete the section definitely when we have more information on the new v3 and v4 direction.

I also removed mentions of validators, since this is also not on the roadmap.