### PR TITLE
adjusted code of conducts

### DIFF
--- a/src/contribute/code_conduct.md
+++ b/src/contribute/code_conduct.md
@@ -287,11 +287,11 @@ The following provisions survive the end of our agreement: [Your Content](#your-
 
 ## Disputes
 
-ascsac will govern any dispute related to these terms or your use of the forum.
+The governing law will govern any dispute related to these terms or your use of the forum.
 
-You and the company agree to seek injunctions related to these terms only in state or federal court in city_for_disputes. Neither you nor the company will object to jurisdiction, forum, or venue in those courts.
+You and the company agree to seek injunctions related to these terms only in state or federal court in the city for disputes. Neither you nor the company will object to jurisdiction, forum, or venue in those courts.
 
-Other than to seek an injunction or for claims under the Computer Fraud and Abuse Act, you and the company will resolve any dispute by binding American Arbitration Association arbitration. Arbitration will follow the AAA’s Commercial Arbitration Rules and Supplementary Procedures for Consumer Related Disputes. Arbitration will happen in city_for_disputes. You will settle any dispute as an individual, and not as part of a class action or other representative proceeding, whether as the plaintiff or a class member. No arbitrator will consolidate any dispute with any other arbitration without the company’s permission.
+Other than to seek an injunction or for claims under the Computer Fraud and Abuse Act, you and the company will resolve any dispute by binding American Arbitration Association arbitration. Arbitration will follow the AAA’s Commercial Arbitration Rules and Supplementary Procedures for Consumer Related Disputes. Arbitration will happen in the city for disputes. You will settle any dispute as an individual, and not as part of a class action or other representative proceeding, whether as the plaintiff or a class member. No arbitrator will consolidate any dispute with any other arbitration without the company’s permission.
 
 Any arbitration award will include costs of the arbitration, reasonable attorneys’ fees, and reasonable costs for witnesses. You and the company may enter arbitration awards in any court with jurisdiction.
 


### PR DESCRIPTION
# Related Issue

To fix issue #393 

# Work Done

In short, the weird typo was supposed to be governing_law. We use Governing law.

For info on this term, [read this](https://ca.practicallaw.thomsonreuters.com/2-603-7906?contextData=(sc.Default)&transitionType=Default&firstPage=true).

As I understand using governing law and "in the city for disputes", if anything arises that goes against the code of conducts, it sets the way to proceed, in this case the governing law is where it's applicable.

@xmonader @sabrinasadik Makes any sense? I hope so. It's clearly better than what is currently there anyway.