### PR TITLE
added dashboard localy setup

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -151,6 +151,7 @@
       - [TFGrid Stacks](documentation/developers/grid_deployment/tfgrid_stacks.md)
       - [Full VM Grid Deployment](documentation/developers/grid_deployment/grid_deployment_full_vm.md)
       - [Grid Snapshots](documentation/developers/grid_deployment/snapshots.md)
+      - [Deploy the Dashboard](documentation/developers/grid_deployment/deploy_dashboard.md)
   - [Farmers](documentation/farmers/farmers.md)
     - [Build a 3Node](documentation/farmers/3node_building/3node_building.md)
       - [1. Create a Farm](documentation/farmers/3node_building/1_create_farm.md)

--- a/src/documentation/developers/developers.md
+++ b/src/documentation/developers/developers.md
@@ -88,3 +88,4 @@ For complementary information on the technology developed by ThreeFold, refer to
   - [TFGrid Stacks](./grid_deployment/tfgrid_stacks.md)
   - [Full VM Grid Deployment](./grid_deployment/grid_deployment_full_vm.md)
   - [Grid Snapshots](./grid_deployment/snapshots.md)
+  - [Deploy the Dashboard](./grid_deployment/deploy_dashboard.md)

--- a/src/documentation/developers/grid_deployment/deploy_dashboard.md
+++ b/src/documentation/developers/grid_deployment/deploy_dashboard.md
@@ -1,0 +1,91 @@
+<h1>Deploy the Dashboard Locally</h1>
+
+<h2>Table of Contents</h2>
+
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Create an SSH Tunnel](#create-an-ssh-tunnel)
+- [VSCode SSH Remote Connection](#vscode-ssh-remote-connection)
+- [Set the VM](#set-the-vm)
+- [Build the Dashboard](#build-the-dashboard)
+
+***
+
+## Introduction
+
+We show how to deploy the Dashboard (devnet) on a full VM. To do so, we set an SSH tunnel and use the VSCodium Remote Explorer function. We will then be able to use a source-code editor to explore the code and see changes on a local browser.
+
+## Prerequisites
+
+- TFChain account with TFT
+- [Deploy full VM with WireGuard connection](../../system_administrators/getstarted/ssh_guide/ssh_wireguard.md)
+- [Make sure you can connect via SSH on the terminal](../../system_administrators/getstarted/ssh_guide/ssh_openssh.md)
+  
+## Create an SSH Tunnel
+
+- Open a terminal and create an SSH tunnel
+    ```
+    ssh -4 -L 5173:127.0.0.1:5173 root@10.20.4.2
+    ```
+
+Simply leave this window open and follow the next steps.
+
+## VSCode SSH Remote Connection
+
+You can connect via SSH through the source-code editor to a VM on the grid. In this example, WireGuard is set.
+
+- Add the SSH Remote extension to VSCodium
+- Add a new SSH remote connection
+- Set the following (adjust with your own username and host)
+  ``` 
+  Host 10.20.4.2
+      HostName 10.20.4.2
+      User root
+  ```
+- Click on `Connect to host`
+
+## Set the VM
+
+We set the VM to be able to build the Dashboard.
+
+```
+
+apt update && apt install build-essential python3 -y
+
+wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+export NVM_DIR="$HOME/.nvm"
+
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" # This loads nvm
+
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" # This loads nvm bash_completion
+
+nvm install 18
+
+apt install wget
+
+npm install -g yarn
+
+```
+
+## Build the Dashboard
+
+We now build the Dashboard.
+
+Clone the repository, then install, build and run the Dashboard. Note that here it is called `playground`:
+
+```
+
+git clone https://github.com/threefoldtech/tfgrid-sdk-ts
+
+cd tfgrid-sdk-ts/
+
+yarn install
+
+make build
+
+make run project=playground
+
+```
+
+You can then access the dev net Dashboard on your local browser.

--- a/src/documentation/developers/grid_deployment/grid_deployment.md
+++ b/src/documentation/developers/grid_deployment/grid_deployment.md
@@ -2,8 +2,11 @@
 
 The TFGrid whole source code is open-source and instances of the grid can be deployed by anyone thanks to the distribution of daily grid snapshots of the complete ThreeFold Grid stacks.
 
+This section also covers the steps to deploy the Dashboard locally. This can be useful when testing the grid or contributing to the open-source project.
+
 ## Table of Contents
 
 - [TFGrid Stacks](./tfgrid_stacks.md)
 - [Full VM Grid Deployment](./grid_deployment_full_vm.md)
 - [Grid Snapshots](./snapshots.md)
+- [Deploy the Dashboard](./deploy_dashboard.md)


### PR DESCRIPTION
# Related Issue

- #467 

# Work Done

- Added guide to deploy dashboard locally
- Can be useful to test the grid or contribute to the project (e.g. test new solutions/features)