### PR TITLE
added backup urls for dashboard

### DIFF
--- a/src/documentation/dashboard/dashboard.md
+++ b/src/documentation/dashboard/dashboard.md
@@ -41,3 +41,12 @@ You can access the ThreeFold Dashboard on different TF Chain networks.
 - Regarding browser support, we're only supporting Google Chrome browser (and thus Brave browser) at the moment with more browsers to be supported soon.
 - Deploys one thing at a time.
 - Might take sometime to deploy a solution like Peertube, so you should wait a little bit until it's fully running.
+
+## Dashboard Backups
+
+If the main Dashboard URLs are not working for any reason, the following URLs can be used. Those Dashboard URLs are fully independent of the main Dashboard URLs shown above.
+
+- [https://dashboard.02.dev.grid.tf](https://dashboard.02.dev.grid.tf) for Dev net
+- [https://dashboard.02.qa.grid.tf](https://dashboard.02.qa.grid.tf) for QA net
+- [https://dashboard.02.test.grid.tf](https://dashboard.02.test.grid.tf) for Test net
+- [https://dashboard.02.grid.tf](https://dashboard.02.grid.tf) for Main net


### PR DESCRIPTION
# Related Issue

- #476 

# Work Done

- Added dashboard backup urls (02) for all networks, as suggested by @coesensbert 