### PR TITLE
removed plan network connector info

### DIFF
--- a/src/documentation/system_administrators/getstarted/planetarynetwork.md
+++ b/src/documentation/system_administrators/getstarted/planetarynetwork.md
@@ -14,7 +14,6 @@
   - [MacOS](#macos-1)
 - [Get Yggdrasil IP](#get-yggdrasil-ip)
 - [Add Peers](#add-peers)
-- [Clients](#clients)
 - [Peers](#peers)
   - [Central europe](#central-europe)
     - [Ghent](#ghent)
@@ -140,10 +139,6 @@ You'll need this address when registering your twin on TFChain later.
 - Restart yggdrasil by
 
         systemctl restart yggdrasil
-
-## Clients
-
-- [planetary network connector](https://github.com/threefoldtech/planetary_network)
 
 ## Peers
 

--- a/src/documentation/system_administrators/getstarted/ssh_guide/ssh_openssh.md
+++ b/src/documentation/system_administrators/getstarted/ssh_guide/ssh_openssh.md
@@ -84,13 +84,7 @@ You now have an SSH connection on Linux with IPv4.
 
 Here are the steps to SSH into a 3Node with the Planetary Network on Linux.
 
-* To download and connect to the Threefold Planetary Network Connector
-  * Download the [.deb file](https://github.com/threefoldtech/planetary_network/releases/tag/v0.3-rc1-Linux)
-  * Right-click and select `Open with other application`
-    * Select `Software Install`
-  * Search the `Threefold Planetary Connector` and open it
-  * Disconnect your VPN if you have one
-  * In the connector, click `Connect`
+* Set a [Planetary Network connection](../planetarynetwork.md)
 * To create the SSH key pair, write in the terminal
   * ```
     ssh-keygen
@@ -163,12 +157,7 @@ You now have an SSH connection on MAC with IPv4.
 
 Here are the steps to SSH into a 3Node with the Planetary Network on MAC.
 
-* To download and connect to the Threefold Planetary Network Connector
-  * Download the [.dmg file](https://github.com/threefoldtech/planetary_network/releases/tag/v0.3-rc1-MacOS)
-  * Run the dmg installer
-  * Search the Threefold Planetary Connector in `Applications` and open it
-  * Disconnect your VPN if you have one
-  * In the connector, click `Connect`
+* Set a [Planetary Network connection](../planetarynetwork.md)
 * To create the SSH key pair, write in the terminal 
     * ```
       ssh-keygen
@@ -246,12 +235,7 @@ You now have an SSH connection on Window with IPv4.
 
 ### SSH into a 3Node with the Planetary Network on Windows
 
-* To download and connect to the Threefold Planetary Network Connector
-  * Download the [.msi file](https://github.com/threefoldtech/planetary_network/releases/tag/v0.3-rc1-Windows10)
-  * Search the `Threefold Planetary Connector`
-    * Right-click and select `Install`
-  * Disconnect your VPN if you have one
-  * Open the TF connector and click `Connect`
+* Set a [Planetary Network connection](../planetarynetwork.md)
 * To download OpenSSH client and OpenSSH server
   * Open the `Settings` and select `Apps`
   * Click `Apps & Features`

--- a/src/documentation/system_administrators/getstarted/ssh_guide/ssh_putty.md
+++ b/src/documentation/system_administrators/getstarted/ssh_guide/ssh_putty.md
@@ -29,7 +29,7 @@ The main steps for the whole process are the following:
 * Deploy a 3Node
   * Choose IPv4 or the Planetary Network
 * SSH into the 3Node
-  * For the Planetary Network, download the Planetary Network Connector
+  * For the Planetary Network, set a [Planetary Network connection](../planetarynetwork.md)
 
 
 


### PR DESCRIPTION
# Related Issue

#491 

# Work Done

- replaced mention of planetary network connector to the planetary network install page
   - the connector is no longer supported. 