### PR TITLE
fixed broken links

### DIFF
--- a/src/documentation/dashboard/solutions/taiga.md
+++ b/src/documentation/dashboard/solutions/taiga.md
@@ -11,7 +11,7 @@
 
 ## Introduction
 
-[Taiga](https://www.taiga.io/) is the project management tool for multi-functional agile teams. It has a rich feature set and at the same time it is very simple to start with through its intuitive user interface.
+[Taiga](https://taiga.io/) is the project management tool for multi-functional agile teams. It has a rich feature set and at the same time it is very simple to start with through its intuitive user interface.
 
 ## Prerequisites
 

--- a/src/knowledge_base/collaboration/collaboration_tools/circle_tool.md
+++ b/src/knowledge_base/collaboration/collaboration_tools/circle_tool.md
@@ -19,7 +19,7 @@
 
 ## Introduction
 
-The [__ThreeFold Circle Tool__](https://circles.threefold.me ) is our own self-hosted (desktop only) project management tool based on [Taiga](https://www.taiga.io/), an open-source project management tool for cross-functional agile. It offers a lot of different project management kits and features such as the scrum board, kanban board, issues management, and many more. 
+The [__ThreeFold Circle Tool__](https://circles.threefold.me ) is our own self-hosted (desktop only) project management tool based on [Taiga](https://taiga.io/), an open-source project management tool for cross-functional agile. It offers a lot of different project management kits and features such as the scrum board, kanban board, issues management, and many more. 
 
 Our teams at ThreeFold use the Circle Tool to self-manage our tasks, thus it is deemed necessary for the new onboarded team members to learn how to use the tool. Unfortunately we only provide the desktop version of the tool at this moment since we normally manage our projects on the computer.
 


### PR DESCRIPTION
# Work Done

- Fixed link
- www.taiga.io didn't work anymore. I guess taiga changed their dns servers, updated links to https://taiga.io