### PR TITLE
V3 title instead of cloud

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,5 @@
 [book]
-title = "ThreeFold Cloud Manual"
+title = "ThreeFold V3 Manual"
 
 [output.html.fold]
 enable = true

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,4 +1,4 @@
-## ThreeFold Cloud Manual Summary
+## ThreeFold Manual Summary
 
 - [Introduction](intro/intro_readme.md)
 - [Documentation](documentation/documentation.md)

--- a/src/documentation/documentation.md
+++ b/src/documentation/documentation.md
@@ -1,8 +1,8 @@
-<h1> ThreeFold Cloud Documentation </h1>
+<h1> ThreeFold Documentation </h1>
 
-The section contains all the practical information for farmers, developers and system administrators of the ThreeFold Cloud.
+The section contains all the practical information for farmers, developers and system administrators of the ThreeFold Grid.
 
-For complementary information on the ThreeFold Cloud, refer to the [ThreeFold Cloud Knowledge Base](../knowledge_base/knowledge_base.md).
+For complementary information on ThreeFold, refer to the [ThreeFold Knowledge Base](../knowledge_base/knowledge_base.md).
 
 **TABLE OF CONTENTS**
 

--- a/src/documentation/system_administrators/system_administrators.md
+++ b/src/documentation/system_administrators/system_administrators.md
@@ -2,7 +2,7 @@
 
 This section covers all practical tutorials for system administrators working on the ThreeFold Grid.
 
-For complementary information on ThreeFold grid and its cloud component, refer to the [Cloud](../../knowledge_base/cloud/cloud_toc.md) section.
+For complementary information on the ThreeFold Grid and its cloud component, refer to the [Cloud](../../knowledge_base/cloud/cloud_toc.md) section.
 
 **TABLE OF CONTENTS**
 

--- a/src/intro/intro_readme.md
+++ b/src/intro/intro_readme.md
@@ -1,23 +1,23 @@
-# ThreeFold Cloud Manual
+# ThreeFold V3 Manual
 
-*Welcome to the ThreeFold Cloud Manual!*
+*Welcome to the ThreeFold V3 Manual!*
 
 This manual is organized in two main sections: 
 
-- [ThreeFold Cloud Knowledge Base](../knowledge_base/knowledge_base.md)
-- [ThreeFold Cloud Documentation](../documentation/documentation.md)
+- [ThreeFold Knowledge Base](../knowledge_base/knowledge_base.md)
+- [ThreeFold Documentation](../documentation/documentation.md)
 
-The *ThreeFold Cloud Knowledge Base* section contains all information needed to understand how the whole ThreeFold ecosystem works. 
+The *ThreeFold Knowledge Base* section contains all information needed to understand how the whole ThreeFold ecosystem works. 
 
-The *ThreeFold Cloud Documentation* section contains all the practical information of the ThreeFold Cloud, from general information covering the multi-functional [ThreeFold Dashboard](../documentation/dashboard/dashboard.md), the versatile [ThreeFold Connect app](../documentation/tfconnect/tfconnect_toc.md) and [TFT](../documentation/threefold_token/threefold_token.md), to specific tutorials for [developers](../documentation/developers/developers.md), [farmers](../documentation/farmers/farmers.md) and [system administrators](../documentation/system_administrators/system_administrators.md).
+The *ThreeFold Documentation* section contains all the practical information of the ThreeFold Grid, from general information covering the multi-functional [ThreeFold Dashboard](../documentation/dashboard/dashboard.md), the versatile [ThreeFold Connect app](../documentation/tfconnect/tfconnect_toc.md) and [TFT](../documentation/threefold_token/threefold_token.md), to specific tutorials for [developers](../documentation/developers/developers.md), [farmers](../documentation/farmers/farmers.md) and [system administrators](../documentation/system_administrators/system_administrators.md).
 
-> Explore the ThreeFold Cloud status page for live updates on Threefold services!
+> Explore the ThreeFold Grid status page for live updates on Threefold services!
 > 
 > [Access with Grid.tf](https://status.grid.tf) | [Access with ThreeFold.io](https://status.threefold.io)
 
 ## Get Started
 
-It's easy to get started on the ThreeFold Cloud. 
+It's easy to get started on the ThreeFold Grid. 
 
 If you want to farm TFT, check out [how to build a 3Node](../documentation/farmers/3node_building/3node_building.md). 
 
@@ -30,7 +30,7 @@ If you want to deploy or develop on the grid, you will first need to get TFT on 
 
 To develop on the Grid, read the [developers documentation](../documentation/developers/developers.md).
 
-To deploy applications, read the [deploy section](../documentation/dashboard/deploy/deploy.md) then [access the deployment via SSH](../documentation/system_administrators/getstarted/ssh_guide/ssh_guide.md).
+To deploy applications, read the [deploy section](../documentation/dashboard/deploy/deploy.md) then, if needed, [access the deployment via SSH](../documentation/system_administrators/getstarted/ssh_guide/ssh_guide.md).
 
 ## Join the ThreeFold Community
 
@@ -47,4 +47,4 @@ To explore this manual, you can use the search function by hitting **'s'** on yo
 
 If you can't find the answer to your question, our dedicated [ThreeFold Support](https://threefoldfaq.crisp.help/en/) team is here to help.
 
-*Welcome to the ThreeFold Cloud, where together we can shape a more sustainable, self-sovereign and autonomous digital future!*
+*Welcome to the ThreeFold Grid, where together we can shape a more sustainable, self-sovereign and autonomous digital future!*

--- a/src/knowledge_base/knowledge_base.md
+++ b/src/knowledge_base/knowledge_base.md
@@ -1,8 +1,8 @@
-<h1> ThreeFold Cloud Knowledge Base </h1>
+<h1> ThreeFold Knowledge Base </h1>
 
-The section contains information about the ThreeFold Cloud ecosystem, its technology and its history.
+The section contains information about the ThreeFold ecosystem, its technology and its history.
 
-For practical information for farmers, developers and system administrators, refer to the [ThreeFold Cloud Documentation](../documentation/documentation.md).
+For practical information for farmers, developers and system administrators, refer to the [ThreeFold Documentation](../documentation/documentation.md).
 
 **TABLE OF CONTENTS**
 

--- a/src/knowledge_base/technology/concepts/tfgrid_by_design.md
+++ b/src/knowledge_base/technology/concepts/tfgrid_by_design.md
@@ -102,7 +102,7 @@ The ThreeFold Manual already contains a lot of resourceful information on how to
 
 ThreeFold is building commercial offerings on top of the TFGrid. Those commercial offerings are for-profit organizations. Each of those organizations would function as a centralized entity.
 
-ThreeFold Ventures will be the branch exploring this aspect of the TF Ecosystem. A major project on the way is [ThreeFold Cloud](https://cloud.threefold.io/). ThreeFold Cloud is thus a centralized entity that will generate its own Terms and Conditions, support, marketing and website strategy. Furthermore, ThreeFold Cloud will be liable to its users to the extent developed in the ThreeFold Cloud Terms and Conditions.
+ThreeFold Ventures will be the branch exploring this aspect of the TF Ecosystem. A major project on the way is [ThreeFold](https://cloud.threefold.io/). ThreeFold is thus a centralized entity that will generate its own Terms and Conditions, support, marketing and website strategy. Furthermore, ThreeFold will be liable to its users to the extent developed in the ThreeFold Terms and Conditions.
 
 # Best Practices
 

--- a/src/knowledge_base/technology/concepts/tfgrid_by_design.md
+++ b/src/knowledge_base/technology/concepts/tfgrid_by_design.md
@@ -100,9 +100,7 @@ The ThreeFold Manual already contains a lot of resourceful information on how to
 
 ## ThreeFold Commercial Offerings
 
-ThreeFold is building commercial offerings on top of the TFGrid. Those commercial offerings are for-profit organizations. Each of those organizations would function as a centralized entity.
-
-ThreeFold Ventures will be the branch exploring this aspect of the TF Ecosystem. A major project on the way is [ThreeFold](https://cloud.threefold.io/). ThreeFold is thus a centralized entity that will generate its own Terms and Conditions, support, marketing and website strategy. Furthermore, ThreeFold will be liable to its users to the extent developed in the ThreeFold Terms and Conditions.
+ThreeFold is building commercial offerings on top of the TFGrid. Those commercial offerings are for-profit organizations. Each of those organizations would function as a centralized entity. ThreeFold Ventures will be the branch exploring this aspect of the TF Ecosystem. 
 
 # Best Practices
 


### PR DESCRIPTION
# Related Issue

- #685

# Work Done

- Revert to V3

@xmonader 

As discussed, reverted back to ThreeFold V3 Manual instead of ThreeFold Cloud, so we stay with V3 specs approved by stakeholders. Of course we can change later if it's decided by the stakeholders.