### PR TITLE
update dedicated to take into account rentable or rented by user

### DIFF
--- a/src/documentation/dashboard/deploy/node_finder.md
+++ b/src/documentation/dashboard/deploy/node_finder.md
@@ -49,13 +49,13 @@ To see only gateway nodes, enable **Gateways** in the filters.
 
 Dedicated machines are 3Nodes that can be reserved and rented entirely by one user. The user can thus reserve an entire node and use it exclusively to deploy solutions. This feature is ideal for users who want to host heavy deployments with the benefits of high reliability and cost effectiveness.
 
-To see only dedicated nodes, enable **Dedicated Nodes** in the filters.
+To see only dedicated nodes, that are either rented by you or rentable, enable **Dedicated Nodes** in the filters.
 
 ![](../img/dashboard_node_finder_dedicated.png)
 
 ### Reservation
 
-When you have decided which node to reserve, you can easily rent it from the Node Finder page.
+When you have decided which node to reserve, you can easily rent it from the `Node Finder` page. You can also rent a dedicated node directly on a deployment page available from the main sections `Virtual Machines`, `Orchestrators` or `Applications`.
 
 To reserve a node, simply click on `Reserve` on the node row.
 

--- a/src/documentation/dashboard/solutions/caprover.md
+++ b/src/documentation/dashboard/solutions/caprover.md
@@ -56,7 +56,7 @@ Use the Leader and Workers tabs to add nodes to your deployment.
     - Or choose a **Custom** plan
 - Choose the network
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the node 
   - Automated

--- a/src/documentation/dashboard/solutions/casper.md
+++ b/src/documentation/dashboard/solutions/casper.md
@@ -25,7 +25,7 @@ __Process__ :
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
 
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/discourse.md
+++ b/src/documentation/dashboard/solutions/discourse.md
@@ -23,7 +23,7 @@
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/fullVm.md
+++ b/src/documentation/dashboard/solutions/fullVm.md
@@ -30,8 +30,8 @@ Deploy a new full virtual machine on the Threefold Grid
   - `Mycelium` to enable Mycelium on the virtual machine
   - `Wireguard Access` to add a wireguard access to the Virtual Machine
 - `GPU` flag to add GPU to the Virtual machine
-  - To deploy a Full VM with GPU, you first need to [rent a dedicated node](../../dashboard/deploy/node_finder.md#dedicated-nodes)
-- `Dedicated` flag to retrieve only dedicated nodes 
+  - To deploy a Full VM with GPU, you first need to [rent a dedicated node](../deploy/node_finder.md#dedicated-nodes)
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
   - `Country`

--- a/src/documentation/dashboard/solutions/funkwhale.md
+++ b/src/documentation/dashboard/solutions/funkwhale.md
@@ -29,7 +29,7 @@ __Process__ :
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/gitea.md
+++ b/src/documentation/dashboard/solutions/gitea.md
@@ -28,7 +28,7 @@
    - `Planetary Network` flag gives the virtual machine an Yggdrasil address
    - `Mycelium` flag gives the virtual machine a Mycelium address
 
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the node 
   - Automated

--- a/src/documentation/dashboard/solutions/jenkins.md
+++ b/src/documentation/dashboard/solutions/jenkins.md
@@ -30,7 +30,7 @@ __Process__ :
    - `Public IPv6` flag gives the virtual machine a Public IPv6
    - `Planetary Network` flag gives the virtual machine an Yggdrasil address
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/jitsi.md
+++ b/src/documentation/dashboard/solutions/jitsi.md
@@ -28,7 +28,7 @@ Jitsi Meet is a set of Open Source projects which empower users to use and deplo
   - `Public IPv6` flag gives the virtual machine a Public IPv6
   - `Planetary Network` flag gives the virtual machine an Yggdrasil address
   - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes
 - Choose the location of the node
 

--- a/src/documentation/dashboard/solutions/mattermost.md
+++ b/src/documentation/dashboard/solutions/mattermost.md
@@ -24,7 +24,7 @@
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/nextcloud.md
+++ b/src/documentation/dashboard/solutions/nextcloud.md
@@ -39,7 +39,7 @@ If you're not sure and just want the easiest, most affordable option, skip the p
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/nodepilot.md
+++ b/src/documentation/dashboard/solutions/nodepilot.md
@@ -21,7 +21,7 @@ This is a simple instance of upstream [Node Pilot](https://nodepilot.tech).
   - 256 MB of memory
   - 15 GB of storage
 
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 
 - Choose the location of the node

--- a/src/documentation/dashboard/solutions/nostr.md
+++ b/src/documentation/dashboard/solutions/nostr.md
@@ -26,7 +26,7 @@
    - `Planetary Network` flag gives the virtual machine an Yggdrasil address
    - `Mycelium` flag gives the virtual machine a Mycelium address
 
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the node 
   - Automated

--- a/src/documentation/dashboard/solutions/owncloud.md
+++ b/src/documentation/dashboard/solutions/owncloud.md
@@ -29,7 +29,7 @@
     - Or choose a **Custom** plan
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
-- Enable the `Dedicated` flag to retrieve only dedicated nodes 
+- Enable the `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - Enable the `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/peertube.md
+++ b/src/documentation/dashboard/solutions/peertube.md
@@ -24,7 +24,7 @@
     - Or choose a **Custom** plan
 - Choose the network
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/presearch.md
+++ b/src/documentation/dashboard/solutions/presearch.md
@@ -23,7 +23,7 @@
    - `Planetary Network` to connect the Virtual Machine to Planetary network
    - `Mycelium` flag gives the virtual machine a Mycelium address
 
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/static_website.md
+++ b/src/documentation/dashboard/solutions/static_website.md
@@ -31,7 +31,7 @@ Static Website is an application where a user provides a GitHub repository URL f
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes
 - Choose the location of the node
   - `Region`

--- a/src/documentation/dashboard/solutions/subsquid.md
+++ b/src/documentation/dashboard/solutions/subsquid.md
@@ -26,7 +26,7 @@
     - Or choose a **Custom** plan
 - Choose the network
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/taiga.md
+++ b/src/documentation/dashboard/solutions/taiga.md
@@ -25,7 +25,7 @@
 - Choose the network
    - `Public IPv4` flag gives the virtual machine a Public IPv4
    - `Mycelium` flag gives the virtual machine a Mycelium address
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/tfrobot.md
+++ b/src/documentation/dashboard/solutions/tfrobot.md
@@ -34,7 +34,7 @@
   - `Planetary Network` to connect the Virtual Machine to Planetary network
   - `Mycelium` to enable Mycelium on the virtual machine
   - `Wireguard Access` to add a wireguard access to the Virtual Machine
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/umbrel.md
+++ b/src/documentation/dashboard/solutions/umbrel.md
@@ -29,7 +29,7 @@
   - `Planetary Network` to connect the Virtual Machine to Planetary network
   - `Mycelium` to enable Mycelium on the virtual machine
   - `Wireguard Access` to add a wireguard access to the Virtual Machine
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/vm.md
+++ b/src/documentation/dashboard/solutions/vm.md
@@ -31,7 +31,7 @@ __Process__ :
   - `Mycelium` to enable Mycelium on the virtual machine
   - `Wireguard Access` to add a wireguard acces to the Virtual Machine
 - `GPU` flag to add GPU to the Virtual machine
-- `Dedicated` flag to retrieve only dedicated nodes 
+- `Dedicated` flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - `Certified` flag to retrieve only certified nodes 
 - Choose the location of the node
    - `Region`

--- a/src/documentation/dashboard/solutions/wordpress.md
+++ b/src/documentation/dashboard/solutions/wordpress.md
@@ -71,7 +71,7 @@ In this section, we cover the steps to deploy a WordPress instance on the Playgr
 - Choose the network
   - `Public IPv4` flag gives the virtual machine a Public IPv4
   - `Mycelium` to enable Mycelium on the virtual machine
-- **Dedicated** flag to retrieve only dedicated nodes 
+- **Dedicated** flag to retrieve only [dedicated nodes](../deploy/node_finder.md#dedicated-nodes) (rentable or rented by you)
 - **Certified** flag to retrieve only certified nodes 
 - Choose the location of the node
    - **Country**


### PR DESCRIPTION
# Related Issue

- #705

# Work Done

- Explained in dedicated note section that you can rent from node finder or any deployment page
- Added info on each solution that dedicated node filter shows both rentable and rented by user dedicated nodes

# Notes

Closes #705 