### PR TITLE
Fix links after latest PR to development

### DIFF
--- a/src/documentation/system_administrators/advanced/grid3_redis.md
+++ b/src/documentation/system_administrators/advanced/grid3_redis.md
@@ -14,7 +14,7 @@ Redis is widely used in various use cases, including caching, session management
 
 ### Linux
 
-If you don't find Redis in your Linux distro's package manager, check the [Redis downloads](https://redis.io/download) page for the source code and installation instructions.
+If you don't find Redis in your Linux distro's package manager, check the [Redis downloads](https://redis.io/downloads/) page for the source code and installation instructions.
 
 ### MacOS
 
@@ -25,7 +25,7 @@ brew update
 brew install redis
 ```
 
-Alternatively, it can be built from source, using the same [download page](https://redis.io/download/) as shown above.
+Alternatively, it can be built from source, using the same [download page](https://redis.io/downloads/) as shown above.
 
 
 

--- a/src/knowledge_base/releasenotes/tfgrid_release_3_0_a2.md
+++ b/src/knowledge_base/releasenotes/tfgrid_release_3_0_a2.md
@@ -103,7 +103,7 @@ Following list is incomplete but gives some issues to think about.
 - Docker & ZOS containers [differences](https://github.com/threefoldtech/zos/issues/1483)
 - ZOS workloads upgrade [issue](https://github.com/threefoldtech/zos/issues/1425)
 - Terraform projects [don't reflect in the weblets](https://github.com/threefoldtech/terraform-provider-grid/issues/146)
-- Can't detach public IP from a VM and removing it from a contract [issue](https://github.com/threefoldtech/tfchain_pallets/issues/73), please note you can still create each in separate contracts.
+- Can't detach public IP from a VM and removing it from a contract [issue](https://github.com/threefoldtech/tfchain/issues/175), please note you can still create each in separate contracts.
 
 # ThreeFold Release Notes TFGrid 3.0.0 Alpha 1 (Live on mainnet)
 
@@ -201,4 +201,4 @@ Following list is incomplete but gives some issues to think about.
 - Docker & ZOS containers [differences](https://github.com/threefoldtech/zos/issues/1483)
 - ZOS workloads upgrade [issue](https://github.com/threefoldtech/zos/issues/1425)
 - Terraform projects [don't reflect in the weblets](https://github.com/threefoldtech/terraform-provider-grid/issues/146)
-- Can't detach public IP from a VM and removing it from a contract [issue](https://github.com/threefoldtech/tfchain_pallets/issues/73), please note you can still create each in separate contracts.
+- Can't detach public IP from a VM and removing it from a contract [issue](https://github.com/threefoldtech/tfchain/issues/175), please note you can still create each in separate contracts.

--- a/src/knowledge_base/releasenotes/tfgrid_release_3_0_a2.md
+++ b/src/knowledge_base/releasenotes/tfgrid_release_3_0_a2.md
@@ -96,7 +96,7 @@ TODO
 
 Following list is incomplete but gives some issues to think about.
 
-- Weblets [limitations](https://library.threefold.me/info/manual/#/manual__weblets_home?id=limitations)
+- Weblets limitations
 - QSFS integration is a work in progress
 - ZOS and SSD performance [issue](https://github.com/threefoldtech/zos/issues/1467)
 - Threefold Connect having [issues](https://circles.threefold.me/project/test-tfgrid3/issue/52) 
@@ -193,7 +193,7 @@ TODO
 
 Following list is incomplete but gives some issues to think about.
 
-- Weblets [limitations](https://library.threefold.me/info/manual/#/manual__weblets_home?id=limitations)
+- Weblets limitations
 - Public IP6 [support](https://github.com/threefoldtech/zos/pull/1488) in ZOS
 - QSFS integration is a work in progress
 - ZOS and SSD performance [issue](https://github.com/threefoldtech/zos/issues/1467)


### PR DESCRIPTION
# Work Done

- Some links were broken, e.g. gh issues moved, or library outdated links
- Tested with website-link checker