### PR TITLE
fix: repair remaining 404 links flagged by the link checker

### DIFF
--- a/labs/docs/documentation/developers/grid3_javascript/grid3_javascript_installation.md
+++ b/labs/docs/documentation/developers/grid3_javascript/grid3_javascript_installation.md
@@ -115,4 +115,4 @@ You can explore the Grid Client by testing the different scripts proposed in **g
 
 ## Reference API
 
-While this is still a work in progress, you can have a look [here](https://threefoldtech.github.io/tfgrid-sdk-ts/packages/grid_client/docs/api/index).
+While this is still a work in progress, you can have a look [here](https://threefoldtech.github.io/zos_sdk_ts/packages/grid_client/docs/api/index).

--- a/labs/docs/documentation/developers/proxy_readme/production.md
+++ b/labs/docs/documentation/developers/proxy_readme/production.md
@@ -93,7 +93,7 @@ docker run --name gridproxy -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432"
 
 - Do `helm lint charts/gridproxy`
 - Regenerate the packages `helm package -u charts/gridproxy`
-- Regenerate index.yaml `helm repo index --url https://threefoldtech.github.io/tfgridclient_proxy/ .`
+- Regenerate index.yaml `helm repo index --url https://threefoldtecharchive.github.io/tfgridclient_proxy/ .`
 - Push your changes
 
 ## Install the chart using helm package
@@ -101,7 +101,7 @@ docker run --name gridproxy -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432"
 - Adding the repo to your helm
 
   ```bash
-  helm repo add gridproxy https://threefoldtech.github.io/tfgridclient_proxy/
+  helm repo add gridproxy https://threefoldtecharchive.github.io/tfgridclient_proxy/
   ```
 
 - install a chart

--- a/labs/docs/documentation/farmers/farming_optimization/minting_receipts.md
+++ b/labs/docs/documentation/farmers/farming_optimization/minting_receipts.md
@@ -75,7 +75,7 @@ The minting receipts contain the following information:
 
 ## Alpha Minting Tool
 
-You can query additional minting information by using the [Dashboard Alpha Minting tool](https://dashboard.grid.tf/other/minting).
+You can query additional minting information by using the [TF Minting Reports tool on the Dashboard](https://dashboard.grid.tf/#/tf-chain/minting-reports/).
 
 - Download the minting receipts of your farm or of a single 3Node
 - Copy a minting receipt hash

--- a/labs/docs/documentation/system_administrators/advanced/hummingbot.md
+++ b/labs/docs/documentation/system_administrators/advanced/hummingbot.md
@@ -71,6 +71,6 @@ You should now see the Hummingbot page.
 
 ## References
 
-The information to install Hummingbot have been taken directly from their [documentation](https://hummingbot.org/installation/docker/).
+The information to install Hummingbot have been taken directly from their [documentation](https://hummingbot.org/installation/).
 
 For any advanced configurations, you may refer to the Hummingbot documentation.

--- a/labs/docs/documentation/threefold_token/buy_sell_tft/tft_lobstr_short_guide.md
+++ b/labs/docs/documentation/threefold_token/buy_sell_tft/tft_lobstr_short_guide.md
@@ -13,7 +13,7 @@ In this guide, we show how to buy and sell ThreeFold Tokens with [Lobstr wallet]
 
 Lobstr is an app for managing digital assets like TFT on the Stellar blockchain. In this case, we'll first obtain Stellar's native currency, Lumens (XLM) and swap them for TFT.
 
-> [Moonpay](https://www.moonpay.com/) is the service integrated in Lobstr to enable users to buy digital assets like XLM with fiat currencies like US Dollars and Euros. Moonpay is available in most regions, but there are some [exceptions](https://support.moonpay.com/hc/en-gb/articles/6557330712721-What-are-our-non-supported-countries-states-and-territories-for-on-ramp-product). If your country or state isn't supported by Moonpay, you will need to find another cryptocurrency exchange or on ramp to obtain XLM. From there, you can follow the rest of this guide.
+> [Moonpay](https://www.moonpay.com/) is the service integrated in Lobstr to enable users to buy digital assets like XLM with fiat currencies like US Dollars and Euros. Moonpay is available in most regions, but there are some [exceptions](https://support.moonpay.com/en/articles/380968-moonpay-s-unsupported-countries). If your country or state isn't supported by Moonpay, you will need to find another cryptocurrency exchange or on ramp to obtain XLM. From there, you can follow the rest of this guide.
 
 ## Install Lobstr
 

--- a/labs/docs/documentation/threefold_token/storing_tft/metamask.md
+++ b/labs/docs/documentation/threefold_token/storing_tft/metamask.md
@@ -39,7 +39,7 @@ We present the steps on BSC. Make sure to switch to Ethereum and to use the TFT 
 
 ### Install & Create Metamask Account
 
-Go to the [Metamask website](https://metamask.io/) to download and install the Metamask extension for your browser. Follow [this tutorial](https://support.metamask.io/hc/en-us/articles/360015489531-Getting-started-with-MetaMask) to install metamask to your preferred browser and create. 
+Go to the [Metamask website](https://metamask.io/) to download and install the Metamask extension for your browser. Follow [this tutorial](https://support.metamask.io/start/getting-started-with-metamask/) to install metamask to your preferred browser and create. 
 
 Once you’ve installed MetaMask, you’ll see the small fox icon at the top right of your screen, and a notification will appear, letting you know that the install was successful.
 


### PR DESCRIPTION
Follow-up to #854. Clears the remaining `Error 404` hits so **Check for Broken Links** can go green.

## The four the checker reported

| link | fix |
| --- | --- |
| MoonPay `hc/…on-ramp-product` | → `support.moonpay.com/en/articles/380968-…` |
| `hummingbot.org/installation/docker/` | → `/installation/` |
| MetaMask `hc/…360015489531` | → `/start/getting-started-with-metamask/` |
| `threefoldtech.github.io/tfgrid-sdk-ts/…` | → `…/zos_sdk_ts/…` |

That last one was **missed by #854** — that sweep matched `github.com/…` URLs but not `github.io/…` ones.

## Three more found by sweeping proactively

Rather than wait for the next red build, I extracted all **919** unique external URLs in the manual and tested every one for the codes the checker treats as fatal (404/501/503/504):

- **gridproxy helm repo (x2)** — `threefoldtech.github.io/tfgridclient_proxy/` 404s; repo moved to the archive org. Verified the new URL serves a valid `index.yaml`, so `helm repo add` actually works again. These sit in code blocks so the checker never flagged them, but they were broken for anyone copy-pasting.
- **Minting receipts** — `dashboard.grid.tf/other/minting` is gone. Located the current route in the dashboard bundle (`/tf-chain/minting-reports/`) and confirmed in a browser that it resolves. The page already tells readers to go **TFChain → TF Minting Reports**, so only the URL was stale; label updated to match.

## Deliberately not changed

- **TestLodge** (`app.testlodge.com/…/suites/234919`) — the checker sees it as a **403 warning**, not an error, so it won't fail the build. It is a private SaaS suite that no reader can open, but removing it is an editorial call, so I left it.
- Placeholder URLs in code blocks (`localhost:8989`, `hub.docker.com/u/<account_name>`, `YOUR_GIT_ACCOUNT`, Debian buster netboot) — examples, not links, and not followed by the checker.

## Worth knowing about the checker

The run only visited **93 pages**, so its coverage is partial — it never reached the minting link above. Passing this job is not the same as the manual being link-clean; the 919-URL sweep above is the stronger check.