### PR TITLE
Dev to Master Sync: remaining link fixes

### DIFF
--- a/labs/docs/documentation/developers/grid3_javascript/grid3_javascript_installation.md
+++ b/labs/docs/documentation/developers/grid3_javascript/grid3_javascript_installation.md
@@ -115,4 +115,4 @@ You can explore the Grid Client by testing the different scripts proposed in **g
 
 ## Reference API
 
-While this is still a work in progress, you can have a look [here](https://threefoldtech.github.io/tfgrid-sdk-ts/packages/grid_client/docs/api/index).
+While this is still a work in progress, you can have a look [here](https://threefoldtech.github.io/zos_sdk_ts/packages/grid_client/docs/api/index).

--- a/labs/docs/documentation/developers/proxy_readme/production.md
+++ b/labs/docs/documentation/developers/proxy_readme/production.md
@@ -93,7 +93,7 @@ docker run --name gridproxy -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432"
 
 - Do `helm lint charts/gridproxy`
 - Regenerate the packages `helm package -u charts/gridproxy`
-- Regenerate index.yaml `helm repo index --url https://threefoldtech.github.io/tfgridclient_proxy/ .`
+- Regenerate index.yaml `helm repo index --url https://threefoldtecharchive.github.io/tfgridclient_proxy/ .`
 - Push your changes
 
 ## Install the chart using helm package
@@ -101,7 +101,7 @@ docker run --name gridproxy -e POSTGRES_HOST="127.0.0.1" -e POSTGRES_PORT="5432"
 - Adding the repo to your helm
 
   ```bash
-  helm repo add gridproxy https://threefoldtech.github.io/tfgridclient_proxy/
+  helm repo add gridproxy https://threefoldtecharchive.github.io/tfgridclient_proxy/
   ```
 
 - install a chart

--- a/labs/docs/documentation/farmers/farming_optimization/minting_receipts.md
+++ b/labs/docs/documentation/farmers/farming_optimization/minting_receipts.md
@@ -75,7 +75,7 @@ The minting receipts contain the following information:
 
 ## Alpha Minting Tool
 
-You can query additional minting information by using the [Dashboard Alpha Minting tool](https://dashboard.grid.tf/other/minting).
+You can query additional minting information by using the [TF Minting Reports tool on the Dashboard](https://dashboard.grid.tf/#/tf-chain/minting-reports/).
 
 - Download the minting receipts of your farm or of a single 3Node
 - Copy a minting receipt hash

--- a/labs/docs/documentation/system_administrators/advanced/hummingbot.md
+++ b/labs/docs/documentation/system_administrators/advanced/hummingbot.md
@@ -71,6 +71,6 @@ You should now see the Hummingbot page.
 
 ## References
 
-The information to install Hummingbot have been taken directly from their [documentation](https://hummingbot.org/installation/docker/).
+The information to install Hummingbot have been taken directly from their [documentation](https://hummingbot.org/installation/).
 
 For any advanced configurations, you may refer to the Hummingbot documentation.

--- a/labs/docs/documentation/threefold_token/buy_sell_tft/tft_lobstr_short_guide.md
+++ b/labs/docs/documentation/threefold_token/buy_sell_tft/tft_lobstr_short_guide.md
@@ -13,7 +13,7 @@ In this guide, we show how to buy and sell ThreeFold Tokens with [Lobstr wallet]
 
 Lobstr is an app for managing digital assets like TFT on the Stellar blockchain. In this case, we'll first obtain Stellar's native currency, Lumens (XLM) and swap them for TFT.
 
-> [Moonpay](https://www.moonpay.com/) is the service integrated in Lobstr to enable users to buy digital assets like XLM with fiat currencies like US Dollars and Euros. Moonpay is available in most regions, but there are some [exceptions](https://support.moonpay.com/hc/en-gb/articles/6557330712721-What-are-our-non-supported-countries-states-and-territories-for-on-ramp-product). If your country or state isn't supported by Moonpay, you will need to find another cryptocurrency exchange or on ramp to obtain XLM. From there, you can follow the rest of this guide.
+> [Moonpay](https://www.moonpay.com/) is the service integrated in Lobstr to enable users to buy digital assets like XLM with fiat currencies like US Dollars and Euros. Moonpay is available in most regions, but there are some [exceptions](https://support.moonpay.com/en/articles/380968-moonpay-s-unsupported-countries). If your country or state isn't supported by Moonpay, you will need to find another cryptocurrency exchange or on ramp to obtain XLM. From there, you can follow the rest of this guide.
 
 ## Install Lobstr
 

--- a/labs/docs/documentation/threefold_token/storing_tft/metamask.md
+++ b/labs/docs/documentation/threefold_token/storing_tft/metamask.md
@@ -39,7 +39,7 @@ We present the steps on BSC. Make sure to switch to Ethereum and to use the TFT 
 
 ### Install & Create Metamask Account
 
-Go to the [Metamask website](https://metamask.io/) to download and install the Metamask extension for your browser. Follow [this tutorial](https://support.metamask.io/hc/en-us/articles/360015489531-Getting-started-with-MetaMask) to install metamask to your preferred browser and create. 
+Go to the [Metamask website](https://metamask.io/) to download and install the Metamask extension for your browser. Follow [this tutorial](https://support.metamask.io/start/getting-started-with-metamask/) to install metamask to your preferred browser and create. 
 
 Once you’ve installed MetaMask, you’ll see the small fox icon at the top right of your screen, and a notification will appear, letting you know that the install was successful.
 


### PR DESCRIPTION
Syncs `development` to `master`. Contains #856 — clears the remaining `Error 404` links flagged by the link checker, plus three more found by sweeping all 919 external URLs.