### PR TITLE
docs: rewrite the wipe-all-disks guide

### DIFF
--- a/farmers/docs/3node_building/4_wipe_all_disks.md
+++ b/farmers/docs/3node_building/4_wipe_all_disks.md
@@ -38,18 +38,20 @@ When you boot the Linux ISO image, make sure to choose *Try Mode*. Otherwise, it
 
 If you are using GRML, simply boot the USB key with the GRML bootstrap image, select GRML then press `q` to enter the shell mode. Once this is done, the next steps are similar to the Ubuntu method: you will use `lsblk` and `wipefs` commands to identify and wipe the disks.
 
-## 3. Use wipefs to Wipe All the Disks
+## 3. Wipe All the Disks
 
-We will now use `wipefs` to remove all the data on the disks.
+We will now remove the partition table and every filesystem signature from the disks. This is what Zero-OS needs in order to boot and claim the disks.
 
-> Important: Make sure that you have no important data on your disks, or make sure that you have copies of your disks before proceeding. 
+> **Important:** This destroys all data on the disks. Make sure you have no important data on your disks, or that you have copies of it, before proceeding.
 
 Once Linux is booted, open the terminal.
 
-First, you can check the available disks by writing the command:
+### 3.1 Identify Your Disks
+
+First, list the disks:
 
 ```
-lsblk
+lsblk -o NAME,SIZE,TYPE,TRAN,FSTYPE,MOUNTPOINTS
 ```
 
 The types of disk you can see are:
@@ -58,34 +60,158 @@ The types of disk you can see are:
   - SATA type
   - e.g. `sda`
   - Note: It can be an SSD disk or a USB key
-- `nvmeX`
+- `nvmeXnY`
   - NVMe type
   - e.g. `nvme0n1`
 
-### SATA Disks
+**Before going further, find the USB key you are currently running from.** It is the disk that shows `/cdrom`, `/rofs` or `/run/live/medium` in the `MOUNTPOINTS` column, and it usually shows `usb` in the `TRAN` column. Never wipe that disk: you are booted from it.
 
-To wipe one specific SATA disk at a time, use the following command by replacing `sdX`  with the specific disk (e.g. `sda`):
-
-```
-wipefs -af /dev/sdX
-```
-
-To wipe all SATA disks (except the Linux distro USB disk you are currently using to run Ubuntu in *Try Mode*), take note of the Linux distro USB disk (e.g. `sdb`) and replace `sdX` with it in the following line:
+You can also ask Linux directly which disk you booted from:
 
 ```
-for i in /dev/sd*; do if [ "$i"!= "/dev/sdX"* ]; then wipefs -af $i; fi; done
+lsblk -no PKNAME "$(findmnt -no SOURCE /cdrom 2>/dev/null || findmnt -no SOURCE /run/live/medium 2>/dev/null)"
 ```
 
-### NVMe Disks
+### 3.2 Wipe One Disk at a Time
 
-To wipe one specific NVMe disk at a time, use the following command by replacing `nvmeX` with the specific disk (e.g. `nvme0n1`) :
+This is the recommended method: you name one disk explicitly, so there is no risk of wiping the wrong one.
 
-```
-wipefs -af /dev/nvmeX
-```
-
-To wipe all NVMe disks, use the following line: 
+Set the disk you want to wipe, then run the block below as is. Replace `/dev/sda` with your disk (e.g. `/dev/nvme0n1`).
 
 ```
-for i in /dev/nvme*; do wipefs -af $i; done
+DISK=/dev/sda
+PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+
+# 1. Release the disk (a busy disk cannot be wiped)
+[ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+[ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+sudo mdadm --stop --scan 2>/dev/null
+sudo vgchange -an        2>/dev/null
+
+# 2. Wipe it
+[ -n "$PARTS" ] && sudo wipefs -af $PARTS
+sudo sgdisk --zap-all "$DISK"
+sudo wipefs -af "$DISK"
+
+# 3. Make the kernel re-read the disk
+sudo partprobe "$DISK"
+sudo udevadm settle
 ```
+
+Each part matters:
+
+- **Release the disk.** Ubuntu's *Try Mode* automatically mounts partitions it finds and can activate swap on them. A disk that is mounted, in use as swap, or held by a software RAID array or an LVM volume group cannot be wiped. This is the single most common reason a wipe appears to do nothing.
+- **`wipefs` on the partitions, then the disk.** Wiping only the disk leaves the filesystem signatures that live inside each partition. Those can reappear later.
+- **`sgdisk --zap-all`** removes both the primary GPT header at the start of the disk and the backup GPT header at the end, plus the MBR.
+- **`partprobe` and `udevadm settle`** make the kernel re-read the disk, so the verification below shows the real state rather than a cached one.
+
+> If you get `sgdisk: command not found`, install it with `sudo apt update && sudo apt install -y gdisk`, then run the block again.
+
+Repeat this for every disk in the machine, then verify each one.
+
+### 3.3 Verify the Disk Is Wiped
+
+Do not skip this step. A wipe can fail without printing an obvious error.
+
+```
+lsblk -o NAME,SIZE,TYPE,FSTYPE,PTTYPE,MOUNTPOINTS "$DISK"
+sudo wipefs -n "$DISK"
+sudo fdisk -l "$DISK"
+```
+
+The disk is properly wiped when **all three** of these are true:
+
+- `lsblk` shows only the disk itself, with **no partition lines** underneath it, and the `FSTYPE` and `PTTYPE` columns are empty.
+- `sudo wipefs -n "$DISK"` prints **nothing at all**. This command only reports signatures, it does not change anything. Any line it prints is a signature still on the disk.
+- `sudo fdisk -l "$DISK"` shows the disk size but reports no partition table and lists no partitions.
+
+If any signature is still reported, run the wipe block from section 3.2 again, then check the [Troubleshooting](#35-troubleshooting) section below.
+
+### 3.4 Wipe All Disks at Once
+
+Once you are comfortable with the steps above, you can wipe every disk in one go. This method detects the USB key you booted from and skips it.
+
+**First, do a dry run.** This only prints what would happen and changes nothing:
+
+```
+LIVE=$(lsblk -no PKNAME "$(findmnt -no SOURCE /cdrom 2>/dev/null || findmnt -no SOURCE /run/live/medium 2>/dev/null)" 2>/dev/null)
+echo "Live USB detected as: ${LIVE:-NONE}"
+
+for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+  if [ "$d" = "$LIVE" ]; then echo "  SKIP  /dev/$d  (this is your Linux USB)"
+  else                        echo "  WIPE  /dev/$d"; fi
+done
+```
+
+Read that list carefully. Every disk marked `WIPE` will be erased, and your Linux USB must be marked `SKIP`.
+
+If `Live USB detected as: NONE` is printed, the detection failed. **Do not run the next block** — wipe the disks one at a time using section 3.2 instead.
+
+If the list is correct, run the wipe:
+
+```
+if [ -z "$LIVE" ]; then
+  echo "Live USB not detected. Use the one-disk-at-a-time method instead."
+else
+  # Release any software RAID array or LVM volume group first,
+  # otherwise the disks they hold are busy and cannot be wiped.
+  sudo mdadm --stop --scan 2>/dev/null
+  sudo vgchange -an        2>/dev/null
+
+  for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+    [ "$d" = "$LIVE" ] && continue
+    DISK=/dev/$d
+    echo "=== Wiping $DISK ==="
+    PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+    [ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+    [ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+    [ -n "$PARTS" ] && sudo wipefs -af $PARTS
+    sudo sgdisk --zap-all "$DISK"
+    sudo wipefs -af "$DISK"
+    sudo partprobe "$DISK"
+  done
+  sudo udevadm settle
+fi
+```
+
+Then verify every disk:
+
+```
+for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+  echo "=== /dev/$d ==="
+  sudo wipefs -n "/dev/$d"
+done
+```
+
+Every disk except your Linux USB must print nothing.
+
+### 3.5 Troubleshooting
+
+**`Device or resource busy`, or the wipe seems to do nothing.**
+
+Something is still holding the disk. Find out what:
+
+```
+cat /proc/mdstat          # software RAID arrays
+sudo dmsetup ls           # LVM / device-mapper
+sudo swapon --show        # active swap
+lsblk -o NAME,MOUNTPOINTS # anything still mounted
+```
+
+Then stop it (`sudo mdadm --stop --scan`, `sudo vgchange -an`, `sudo swapoff -a`, `sudo umount ...`) and wipe again.
+
+**`sgdisk: command not found`.**
+
+Install it: `sudo apt update && sudo apt install -y gdisk`.
+
+**The disk still shows partitions after wiping.**
+
+The kernel has not re-read the partition table. Run `sudo partprobe "$DISK"` and `sudo udevadm settle`. If it persists, reboot into *Try Mode* again and re-check with `sudo wipefs -n "$DISK"`.
+
+**The disks do not appear at all in `lsblk`.**
+
+The machine likely has a hardware RAID controller presenting the disks as a RAID volume instead of individual disks. Zero-OS needs direct access to each disk. Set the controller to HBA / IT mode, or replace it. See the [farming troubleshooting section](/labs/documentation/farmers/farming_troubleshooting/farming_troubleshooting_tips) of the manual for more on RAID controllers.
+
+**Zero-OS still refuses to boot after wiping.**
+
+Make sure you wiped *every* disk in the machine, not just the one you intend to use, and verify each with `sudo wipefs -n`. More build and post-build troubleshooting is available in the [farming troubleshooting section](/labs/documentation/farmers/farming_troubleshooting/farming_troubleshooting_tips) of the manual.

--- a/labs/docs/documentation/farmers/3node_building/4_wipe_all_disks.md
+++ b/labs/docs/documentation/farmers/3node_building/4_wipe_all_disks.md
@@ -39,18 +39,20 @@ When you boot the Linux ISO image, make sure to choose *Try Mode*. Otherwise, it
 
 If you are using GRML, simply boot the USB key with the GRML bootstrap image, select GRML then press `q` to enter the shell mode. Once this is done, the next steps are similar to the Ubuntu method: you will use `lsblk` and `wipefs` commands to identify and wipe the disks.
 
-## 3. Use wipefs to Wipe All the Disks
+## 3. Wipe All the Disks
 
-We will now use `wipefs` to remove all the data on the disks.
+We will now remove the partition table and every filesystem signature from the disks. This is what Zero-OS needs in order to boot and claim the disks.
 
-> Important: Make sure that you have no important data on your disks, or make sure that you have copies of your disks before proceeding. 
+> **Important:** This destroys all data on the disks. Make sure you have no important data on your disks, or that you have copies of it, before proceeding.
 
 Once Linux is booted, open the terminal.
 
-First, you can check the available disks by writing the command:
+### 3.1 Identify Your Disks
+
+First, list the disks:
 
 ```
-lsblk
+lsblk -o NAME,SIZE,TYPE,TRAN,FSTYPE,MOUNTPOINTS
 ```
 
 The types of disk you can see are:
@@ -59,34 +61,158 @@ The types of disk you can see are:
   - SATA type
   - e.g. `sda`
   - Note: It can be an SSD disk or a USB key
-- `nvmeX`
+- `nvmeXnY`
   - NVMe type
   - e.g. `nvme0n1`
 
-### SATA Disks
+**Before going further, find the USB key you are currently running from.** It is the disk that shows `/cdrom`, `/rofs` or `/run/live/medium` in the `MOUNTPOINTS` column, and it usually shows `usb` in the `TRAN` column. Never wipe that disk: you are booted from it.
 
-To wipe one specific SATA disk at a time, use the following command by replacing `sdX`  with the specific disk (e.g. `sda`):
-
-```
-wipefs -af /dev/sdX
-```
-
-To wipe all SATA disks (except the Linux distro USB disk you are currently using to run Ubuntu in *Try Mode*), take note of the Linux distro USB disk (e.g. `sdb`) and replace `sdX` with it in the following line:
+You can also ask Linux directly which disk you booted from:
 
 ```
-for i in /dev/sd*; do if [ "$i"!= "/dev/sdX"* ]; then wipefs -af $i; fi; done
+lsblk -no PKNAME "$(findmnt -no SOURCE /cdrom 2>/dev/null || findmnt -no SOURCE /run/live/medium 2>/dev/null)"
 ```
 
-### NVMe Disks
+### 3.2 Wipe One Disk at a Time
 
-To wipe one specific NVMe disk at a time, use the following command by replacing `nvmeX` with the specific disk (e.g. `nvme0n1`) :
+This is the recommended method: you name one disk explicitly, so there is no risk of wiping the wrong one.
 
-```
-wipefs -af /dev/nvmeX
-```
-
-To wipe all NVMe disks, use the following line: 
+Set the disk you want to wipe, then run the block below as is. Replace `/dev/sda` with your disk (e.g. `/dev/nvme0n1`).
 
 ```
-for i in /dev/nvme*; do wipefs -af $i; done
+DISK=/dev/sda
+PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+
+# 1. Release the disk (a busy disk cannot be wiped)
+[ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+[ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+sudo mdadm --stop --scan 2>/dev/null
+sudo vgchange -an        2>/dev/null
+
+# 2. Wipe it
+[ -n "$PARTS" ] && sudo wipefs -af $PARTS
+sudo sgdisk --zap-all "$DISK"
+sudo wipefs -af "$DISK"
+
+# 3. Make the kernel re-read the disk
+sudo partprobe "$DISK"
+sudo udevadm settle
 ```
+
+Each part matters:
+
+- **Release the disk.** Ubuntu's *Try Mode* automatically mounts partitions it finds and can activate swap on them. A disk that is mounted, in use as swap, or held by a software RAID array or an LVM volume group cannot be wiped. This is the single most common reason a wipe appears to do nothing.
+- **`wipefs` on the partitions, then the disk.** Wiping only the disk leaves the filesystem signatures that live inside each partition. Those can reappear later.
+- **`sgdisk --zap-all`** removes both the primary GPT header at the start of the disk and the backup GPT header at the end, plus the MBR.
+- **`partprobe` and `udevadm settle`** make the kernel re-read the disk, so the verification below shows the real state rather than a cached one.
+
+> If you get `sgdisk: command not found`, install it with `sudo apt update && sudo apt install -y gdisk`, then run the block again.
+
+Repeat this for every disk in the machine, then verify each one.
+
+### 3.3 Verify the Disk Is Wiped
+
+Do not skip this step. A wipe can fail without printing an obvious error.
+
+```
+lsblk -o NAME,SIZE,TYPE,FSTYPE,PTTYPE,MOUNTPOINTS "$DISK"
+sudo wipefs -n "$DISK"
+sudo fdisk -l "$DISK"
+```
+
+The disk is properly wiped when **all three** of these are true:
+
+- `lsblk` shows only the disk itself, with **no partition lines** underneath it, and the `FSTYPE` and `PTTYPE` columns are empty.
+- `sudo wipefs -n "$DISK"` prints **nothing at all**. This command only reports signatures, it does not change anything. Any line it prints is a signature still on the disk.
+- `sudo fdisk -l "$DISK"` shows the disk size but reports no partition table and lists no partitions.
+
+If any signature is still reported, run the wipe block from section 3.2 again, then check the [Troubleshooting](#35-troubleshooting) section below.
+
+### 3.4 Wipe All Disks at Once
+
+Once you are comfortable with the steps above, you can wipe every disk in one go. This method detects the USB key you booted from and skips it.
+
+**First, do a dry run.** This only prints what would happen and changes nothing:
+
+```
+LIVE=$(lsblk -no PKNAME "$(findmnt -no SOURCE /cdrom 2>/dev/null || findmnt -no SOURCE /run/live/medium 2>/dev/null)" 2>/dev/null)
+echo "Live USB detected as: ${LIVE:-NONE}"
+
+for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+  if [ "$d" = "$LIVE" ]; then echo "  SKIP  /dev/$d  (this is your Linux USB)"
+  else                        echo "  WIPE  /dev/$d"; fi
+done
+```
+
+Read that list carefully. Every disk marked `WIPE` will be erased, and your Linux USB must be marked `SKIP`.
+
+If `Live USB detected as: NONE` is printed, the detection failed. **Do not run the next block** — wipe the disks one at a time using section 3.2 instead.
+
+If the list is correct, run the wipe:
+
+```
+if [ -z "$LIVE" ]; then
+  echo "Live USB not detected. Use the one-disk-at-a-time method instead."
+else
+  # Release any software RAID array or LVM volume group first,
+  # otherwise the disks they hold are busy and cannot be wiped.
+  sudo mdadm --stop --scan 2>/dev/null
+  sudo vgchange -an        2>/dev/null
+
+  for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+    [ "$d" = "$LIVE" ] && continue
+    DISK=/dev/$d
+    echo "=== Wiping $DISK ==="
+    PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+    [ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+    [ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+    [ -n "$PARTS" ] && sudo wipefs -af $PARTS
+    sudo sgdisk --zap-all "$DISK"
+    sudo wipefs -af "$DISK"
+    sudo partprobe "$DISK"
+  done
+  sudo udevadm settle
+fi
+```
+
+Then verify every disk:
+
+```
+for d in $(lsblk -dno NAME,TYPE | awk '$2=="disk" && $1 !~ /^(zram|loop|ram)/ {print $1}'); do
+  echo "=== /dev/$d ==="
+  sudo wipefs -n "/dev/$d"
+done
+```
+
+Every disk except your Linux USB must print nothing.
+
+### 3.5 Troubleshooting
+
+**`Device or resource busy`, or the wipe seems to do nothing.**
+
+Something is still holding the disk. Find out what:
+
+```
+cat /proc/mdstat          # software RAID arrays
+sudo dmsetup ls           # LVM / device-mapper
+sudo swapon --show        # active swap
+lsblk -o NAME,MOUNTPOINTS # anything still mounted
+```
+
+Then stop it (`sudo mdadm --stop --scan`, `sudo vgchange -an`, `sudo swapoff -a`, `sudo umount ...`) and wipe again.
+
+**`sgdisk: command not found`.**
+
+Install it: `sudo apt update && sudo apt install -y gdisk`.
+
+**The disk still shows partitions after wiping.**
+
+The kernel has not re-read the partition table. Run `sudo partprobe "$DISK"` and `sudo udevadm settle`. If it persists, reboot into *Try Mode* again and re-check with `sudo wipefs -n "$DISK"`.
+
+**The disks do not appear at all in `lsblk`.**
+
+The machine likely has a hardware RAID controller presenting the disks as a RAID volume instead of individual disks. Zero-OS needs direct access to each disk. Set the controller to HBA / IT mode, or replace it. See the [farming troubleshooting section](../farming_troubleshooting/farming_troubleshooting_tips) of the manual for more on RAID controllers.
+
+**Zero-OS still refuses to boot after wiping.**
+
+Make sure you wiped *every* disk in the machine, not just the one you intend to use, and verify each with `sudo wipefs -n`. More build and post-build troubleshooting is available in the [farming troubleshooting section](../farming_troubleshooting/farming_troubleshooting_tips) of the manual.

--- a/labs/docs/documentation/farmers/farming_troubleshooting/farming_troubleshooting_tips.md
+++ b/labs/docs/documentation/farmers/farming_troubleshooting/farming_troubleshooting_tips.md
@@ -29,23 +29,30 @@ You might have to try UEFI first and if it doesn't work, try BIOS. Usually when 
 
 And then... nothing. This means that you are still in the BIOS of the hardware and boot is not even started yet. When this happens, try the BIOS mode of your computer. 
 
-### When running wipefs to wipe my disks on Linux, I get either of the following errors: "syntax error near unexpected token" or "Probing Initialized Failed". Is there a fix?
+### When running wipefs to wipe my disks on Linux, I get a shell error, "Probing Initialized Failed", or the wipe appears to do nothing. Is there a fix?
 
-Many different reasons can cause this issue. When you get that error, sometimes it is because your are trying to wipe your boot USB by accident. If this is not the case, and you really are trying to wipe the correct disk, here are some fixes to try out, with the disk `sda` as an example:
+Follow the procedure in [Wipe All the Disks](../3node_building/wipe_all_disks), which releases the disk before wiping it and then verifies the result. The most common causes are below, with the disk `sda` as an example.
 
-* Fix 1:
-  * Force the wiping of the disk:
-    * ```
-      sudo wipefs -af /dev/sda
-      ```
-* Fix 2:
-  * Unmount the disk then wipe it:
-    * ```
-      sudo umount /dev/sda
-      ```
-    * ```
-      sudo wipefs -a /dev/sda
-      ```
+* **The disk is busy.** Ubuntu's *Try Mode* automatically mounts partitions it finds and can activate swap on them. A disk that is mounted, in use as swap, or held by a software RAID array or an LVM volume group cannot be wiped. Release it first:
+  * ```
+    sudo swapoff /dev/sda1 && sudo umount /dev/sda1
+    sudo mdadm --stop --scan
+    sudo vgchange -an
+    ```
+  * To find what is still holding the disk: `cat /proc/mdstat`, `sudo dmsetup ls`, `sudo swapon --show`, `lsblk -o NAME,MOUNTPOINTS`
+* **Only the disk was wiped, not its partitions.** Wipe the partition signatures first, then the disk itself:
+  * ```
+    sudo wipefs -af /dev/sda1 /dev/sda2
+    sudo sgdisk --zap-all /dev/sda
+    sudo wipefs -af /dev/sda
+    ```
+* **You are wiping your boot USB by accident.** Identify the disk you booted from before wiping anything:
+  * ```
+    lsblk -no PKNAME "$(findmnt -no SOURCE /cdrom 2>/dev/null || findmnt -no SOURCE /run/live/medium 2>/dev/null)"
+    ```
+* **`sgdisk: command not found`.** Install it with `sudo apt update && sudo apt install -y gdisk`.
+
+Always confirm the result with `sudo wipefs -n /dev/sda`, which reports remaining signatures without changing anything. It must print nothing.
 
 ### Disk Not Recognized by Zero-OS
 


### PR DESCRIPTION
Rewrites step 3 of the 3Node wipe guide in both the simple (`farmers/`) and advanced (`labs/`) trees, and fixes the related troubleshooting entry.

## Why: the documented command was broken

```bash
for i in /dev/sd*; do if [ "$i"!= "/dev/sdX"* ]; then wipefs -af $i; fi; done
```

Two independent failures, both reproduced:

1. **As written it wipes nothing.** No space before `!=`, so `[` errors on every iteration (`unary operator expected` in bash, `unexpected operator` in dash). The condition is false, the loop completes, **exit code 0**. The farmer sees no failure, then Zero-OS won't boot with no clue why.
2. **Adding the missing space wipes the live USB.** POSIX `[` does no pattern matching, so `"/dev/sdX"*` is a literal string after failed globbing. The exclusion never matches and every disk is wiped, including the one you booted from.

There is field evidence for this already in the manual: `farming_troubleshooting_tips.md` has an entry for *"syntax error near unexpected token"* when wiping, answered with "many different reasons can cause this issue." That is the build guide's own command coming back as a support ticket.

## What replaces it

Step 3 becomes **identify → release → wipe → verify**, with both a per-disk method (recommended, listed first) and a bulk method, per request.

- **Release** (`swapoff`/`umount`/`mdadm --stop`/`vgchange -an`) — new. Ubuntu's *Try Mode* auto-mounts partitions and can activate swap on them; a busy disk cannot be wiped. This is the most common reason a wipe silently does nothing.
- **Wipe** — partitions first, then `sgdisk --zap-all` (primary + backup GPT and MBR), then the device, then `partprobe`/`udevadm settle`.
- **Verify** — new, and the thing that was missing entirely. `wipefs -n` must print **nothing**; `lsblk` must show no partition rows; `fdisk -l` no partition table.
- **Bulk method** detects the live USB, requires a **dry run** printing `SKIP`/`WIPE` per disk, and **refuses to run** if detection fails rather than guessing.
- **Troubleshooting** section for busy devices, missing `sgdisk`, stale partition tables, and RAID controllers, cross-linked to the labs troubleshooting page (the `farmers/` tree has none of its own).

## Two further hazards found while testing

- **`zram` reports `TYPE=disk`.** A naive `lsblk | awk '$2=="disk"'` loop targets `/dev/zram0` — and Ubuntu live sessions use zram for swap. Filtered out.
- **`/dev/sda?*` also matches `/dev/sdaa`**, a *different disk*, on nodes with 27+ disks. Globbing dropped entirely in favour of `lsblk -lnpo NAME`, which is exact and identical for SATA and NVMe (this also collapses the old divergent SATA/NVMe sections into one).

## Verification

- All 8 shell blocks pass `bash -n` — the check the original command would have failed
- Dry-run and guard blocks executed: guard correctly refuses when the live USB is undetected; `zram` correctly excluded
- Rendered locally; the `#35-troubleshooting` anchor verified against the real generated heading ID, and both cross-tree links resolve

## Worth a second opinion

`mdadm --stop --scan` and `vgchange -an` are machine-wide rather than disk-scoped. Correct and safe in a live session, wrong on a running system — the page is explicitly Try-Mode-only, but it is the one call I would want a farmer's eye on.