### PR TITLE
Dev to Master Sync: PR validation + link check split

### DIFF
--- a/.github/workflows/manual_update_development.yml
+++ b/.github/workflows/manual_update_development.yml
@@ -67,25 +67,3 @@ jobs:
           echo "Build directory removed"
           
           echo "Build completed. Web server should serve from the docs directory."
-
-  wait:
-    needs: deploy
-    name: Wait for Website Update
-    runs-on: ubuntu-latest
-    steps:
-    - name: Wait Period
-      id: wait-deploy
-      run: |
-        echo "Sleeping for 30"
-        sleep 30
-        
-  checklinks:
-    needs: wait
-    name: Check for Broken Links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for Broken Links
-        id: link-report
-        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
-        with:
-          args: 'https://manual.dev.grid.tf -e 404 501 503 504 -w all'

--- a/.github/workflows/manual_update_master.yml
+++ b/.github/workflows/manual_update_master.yml
@@ -225,25 +225,3 @@ jobs:
           echo "=== Deployment completed successfully ==="
           echo "Build completed. Web server should serve from the docs directory."
           echo "Deployment timestamp: $(date)"
-
-  wait:
-    needs: deploy
-    name: Wait for Website Update
-    runs-on: ubuntu-latest
-    steps:
-    - name: Wait Period
-      id: wait-deploy
-      run: |
-        echo "Sleeping for 30 seconds to allow website update..."
-        sleep 30
-        
-  checklinks:
-    needs: wait
-    name: Check for Broken Links
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for Broken Links
-        id: link-report
-        uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
-        with:
-          args: 'https://manual.grid.tf -e 404 501 503 504 -w all'

--- a/.github/workflows/manual_weekly_link_check.yml
+++ b/.github/workflows/manual_weekly_link_check.yml
@@ -1,7 +1,19 @@
 name: Weekly Link Check
+
+# Checks the published sites for links that return 404/501/503/504.
+#
+# This job is deliberately NOT part of the deploy pipeline. It checks
+# third-party URLs, which rot on their own schedule with no change to this
+# repo, so it must never block a deploy or a merge. Broken internal links
+# are caught before merge instead, by the build in pr_check.yml.
+#
+# When something breaks, this opens (or comments on) a tracking issue so the
+# rot becomes actionable work rather than a red X nobody reads.
+
 on:
   schedule:
     - cron: '0 6 * * 5'
+  workflow_dispatch:
 
 jobs:
   checkwww:
@@ -23,7 +35,7 @@ jobs:
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
           args: 'https://manual.dev.grid.tf -e 404 501 503 504 -w all'
-        
+
   checkwww3:
     name: Check for Broken Links on www3
     runs-on: ubuntu-latest
@@ -33,3 +45,54 @@ jobs:
         uses: docker://ghcr.io/threefoldfoundation/website-link-checker:latest
         with:
           args: 'https://www3.manual.grid.tf -e 404 501 503 504 -w all'
+
+  report:
+    name: Report broken links
+    needs: [checkwww, checkwww2, checkwww3]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update the tracking issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'Weekly link check: broken links detected';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              'The weekly link check found links returning 404/501/503/504.',
+              '',
+              `Run: ${runUrl}`,
+              '',
+              'Open the failed job(s) in that run to see which links broke and which page each was found on.',
+              'Lines marked `Warning` (403, TLS, timeouts, missing anchors) do not fail the check and can be ignored here.',
+              '',
+              '_Opened automatically by `.github/workflows/manual_weekly_link_check.yml`._',
+            ].join('\n');
+
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = open.find(i => i.title === title && !i.pull_request);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.info(`Commented on existing issue #${existing.number}`);
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+              core.info(`Opened issue #${created.number}`);
+            }

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,0 +1,33 @@
+name: PR Check
+
+# Validates a pull request before it is merged.
+#
+# The site build is the gate: with onBrokenLinks and onBrokenAnchors set to
+# 'throw' in docusaurus.config.js, any broken internal link or anchor fails
+# this job. External links are NOT checked here -- third-party rot must never
+# block a merge. Those are covered by the weekly link check instead.
+
+on:
+  pull_request:
+    branches: [ development, master ]
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        # Fails on broken internal links and anchors.
+        run: npm run build

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,11 +8,12 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
   tagline: 'Documentation for ThreeFold Grid',
   url: 'https://manual.grid.tf',
   baseUrl: '/',
-  onBrokenLinks: 'warn',
+  onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+  onBrokenAnchors: 'throw',
   favicon: 'img/logo_tft_light_short.png',
   organizationName: 'ThreeFold',
-  projectName: 'info_grid',
+  projectName: 'grid_manual',
   markdown: {
     mermaid: true,
   },
@@ -32,14 +33,12 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
         docs: {
           // Generate sidebar from folder structure
           sidebarPath: undefined,
-          // Please change this to your repo.
-          editUrl: 'https://github.com/threefold/manual/edit/main/',
+          editUrl: 'https://github.com/threefoldtech/grid_manual/edit/development/',
 
         },
         blog: {
           showReadingTime: true,
-          // Please change this to your repo.
-          editUrl: 'https://github.com/threefold/manual/edit/main/blog/',
+          editUrl: 'https://github.com/threefoldtech/grid_manual/edit/development/blog/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
Syncs `development` to `master`. Contains #860 — adds PR-time site build validation (nothing validated PRs before), makes broken internal links and anchors fail the build, removes the non-gating post-deploy link check, and has the weekly check file a tracking issue instead of just going red. Also repairs the broken `editUrl` and the stale `projectName`.