### PR TITLE
docs: guard the wipe block on a live session, clarify what erases data

### DIFF
--- a/farmers/docs/3node_building/4_wipe_all_disks.md
+++ b/farmers/docs/3node_building/4_wipe_all_disks.md
@@ -79,23 +79,29 @@ This is the recommended method: you name one disk explicitly, so there is no ris
 Set the disk you want to wipe, then run the block below as is. Replace `/dev/sda` with your disk (e.g. `/dev/nvme0n1`).
 
 ```
-DISK=/dev/sda
-PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+# Only run this from a live USB, never on a machine you are still using.
+if ! findmnt -no SOURCE /cdrom >/dev/null 2>&1 && \
+   ! findmnt -no SOURCE /run/live/medium >/dev/null 2>&1; then
+  echo "Not running from a live USB. Stop here."
+else
+  DISK=/dev/sda
+  PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
 
-# 1. Release the disk (a busy disk cannot be wiped)
-[ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
-[ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
-sudo mdadm --stop --scan 2>/dev/null
-sudo vgchange -an        2>/dev/null
+  # 1. Release the disk (a busy disk cannot be wiped)
+  [ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+  [ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+  sudo mdadm --stop --scan 2>/dev/null
+  sudo vgchange -an        2>/dev/null
 
-# 2. Wipe it
-[ -n "$PARTS" ] && sudo wipefs -af $PARTS
-sudo sgdisk --zap-all "$DISK"
-sudo wipefs -af "$DISK"
+  # 2. Wipe it
+  [ -n "$PARTS" ] && sudo wipefs -af $PARTS
+  sudo sgdisk --zap-all "$DISK"
+  sudo wipefs -af "$DISK"
 
-# 3. Make the kernel re-read the disk
-sudo partprobe "$DISK"
-sudo udevadm settle
+  # 3. Make the kernel re-read the disk
+  sudo partprobe "$DISK"
+  sudo udevadm settle
+fi
 ```
 
 Each part matters:
@@ -104,6 +110,8 @@ Each part matters:
 - **`wipefs` on the partitions, then the disk.** Wiping only the disk leaves the filesystem signatures that live inside each partition. Those can reappear later.
 - **`sgdisk --zap-all`** removes both the primary GPT header at the start of the disk and the backup GPT header at the end, plus the MBR.
 - **`partprobe` and `udevadm settle`** make the kernel re-read the disk, so the verification below shows the real state rather than a cached one.
+
+> **What erases data and what does not.** `mdadm --stop` and `vgchange -an` only *deactivate* RAID arrays and LVM volume groups. They erase nothing, and they fail harmlessly if something is still in use. An array can be brought back with `sudo mdadm --assemble --scan`, and a volume group with `sudo vgchange -ay`. The commands that actually erase data are `wipefs` and `sgdisk`, and both act only on the disk you set in `DISK`.
 
 > If you get `sgdisk: command not found`, install it with `sudo apt update && sudo apt install -y gdisk`, then run the block again.
 

--- a/labs/docs/documentation/farmers/3node_building/4_wipe_all_disks.md
+++ b/labs/docs/documentation/farmers/3node_building/4_wipe_all_disks.md
@@ -80,23 +80,29 @@ This is the recommended method: you name one disk explicitly, so there is no ris
 Set the disk you want to wipe, then run the block below as is. Replace `/dev/sda` with your disk (e.g. `/dev/nvme0n1`).
 
 ```
-DISK=/dev/sda
-PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
+# Only run this from a live USB, never on a machine you are still using.
+if ! findmnt -no SOURCE /cdrom >/dev/null 2>&1 && \
+   ! findmnt -no SOURCE /run/live/medium >/dev/null 2>&1; then
+  echo "Not running from a live USB. Stop here."
+else
+  DISK=/dev/sda
+  PARTS=$(lsblk -lnpo NAME "$DISK" | tail -n +2)
 
-# 1. Release the disk (a busy disk cannot be wiped)
-[ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
-[ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
-sudo mdadm --stop --scan 2>/dev/null
-sudo vgchange -an        2>/dev/null
+  # 1. Release the disk (a busy disk cannot be wiped)
+  [ -n "$PARTS" ] && sudo swapoff $PARTS 2>/dev/null
+  [ -n "$PARTS" ] && sudo umount  $PARTS 2>/dev/null
+  sudo mdadm --stop --scan 2>/dev/null
+  sudo vgchange -an        2>/dev/null
 
-# 2. Wipe it
-[ -n "$PARTS" ] && sudo wipefs -af $PARTS
-sudo sgdisk --zap-all "$DISK"
-sudo wipefs -af "$DISK"
+  # 2. Wipe it
+  [ -n "$PARTS" ] && sudo wipefs -af $PARTS
+  sudo sgdisk --zap-all "$DISK"
+  sudo wipefs -af "$DISK"
 
-# 3. Make the kernel re-read the disk
-sudo partprobe "$DISK"
-sudo udevadm settle
+  # 3. Make the kernel re-read the disk
+  sudo partprobe "$DISK"
+  sudo udevadm settle
+fi
 ```
 
 Each part matters:
@@ -105,6 +111,8 @@ Each part matters:
 - **`wipefs` on the partitions, then the disk.** Wiping only the disk leaves the filesystem signatures that live inside each partition. Those can reappear later.
 - **`sgdisk --zap-all`** removes both the primary GPT header at the start of the disk and the backup GPT header at the end, plus the MBR.
 - **`partprobe` and `udevadm settle`** make the kernel re-read the disk, so the verification below shows the real state rather than a cached one.
+
+> **What erases data and what does not.** `mdadm --stop` and `vgchange -an` only *deactivate* RAID arrays and LVM volume groups. They erase nothing, and they fail harmlessly if something is still in use. An array can be brought back with `sudo mdadm --assemble --scan`, and a volume group with `sudo vgchange -ay`. The commands that actually erase data are `wipefs` and `sgdisk`, and both act only on the disk you set in `DISK`.
 
 > If you get `sgdisk: command not found`, install it with `sudo apt update && sudo apt install -y gdisk`, then run the block again.
 


### PR DESCRIPTION
Follow-up to #858, closing out the concern I raised about the machine-wide RAID/LVM teardown.

## The concern was overstated — here is the accurate picture

`mdadm --stop` and `vgchange -an` **deactivate; they do not erase.** An array comes back with `mdadm --assemble --scan`, a volume group with `vgchange -ay`. They also fail safe — you cannot deactivate a VG with a mounted LV or stop an array in use.

Worst realistic case if run outside Try Mode: an idle array or VG is deactivated and needs reactivating. An availability blip, recoverable, **no data loss**. The commands that actually destroy data are `wipefs` and `sgdisk`, and those were already scoped to `$DISK` behind live-USB detection, a dry run and a guard.

## What this PR changes

1. **Guard the per-disk block on a live session.** It now refuses unless `/cdrom` or `/run/live/medium` is present, making it inert on a running machine — the only realistic misuse.
2. **Say plainly what erases and what does not**, so nobody misreads the teardown as destructive or misapplies it elsewhere.

## Dropped: disk-scoped teardown

I proposed scoping the teardown to the target disk and have decided against it. In this workflow every disk in the machine is being wiped for Zero-OS — there is nothing to preserve — so it would add real complexity to a beginner page to protect against a case that does not occur. Better to keep the simple form and guard the context.

## Verification

- All 8 shell blocks pass `bash -n`
- Guard tested **both ways** with `sudo` replaced by `echo`: refuses off a live USB (no wipe commands reached), and proceeds when a live medium is detected. A guard that silently always refused would have broken the procedure for real farmers, so both paths were checked.