### PR TITLE
docs: fix issues found by a full-manual scan

### DIFF
--- a/farmers/docs/3node_building/2_bootstrap_image.md
+++ b/farmers/docs/3node_building/2_bootstrap_image.md
@@ -70,10 +70,10 @@ That's it. Now you have a bootstrap image on Zero-OS as a bootable removable med
 For the BIOS **USB** and the UEFI **EFI IMG** images, you can do the following on Linux:
 
 ```
-sudo dd status=progress if=FILELOCATION.ISO(or .IMG) of=/dev/sdX
+sudo dd status=progress if=FILELOCATION of=/dev/sdX
 ```
 
-Simply replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
+Replace `FILELOCATION` by the path to the image you downloaded (the `.ISO` or the `.IMG` file), and replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
 
 If you USB key is not new, make sure to format it before burning the Zero-OS image.
 

--- a/labs/docs/documentation/developers/internals/zos/internal_modules/network/introduction.md
+++ b/labs/docs/documentation/developers/internals/zos/internal_modules/network/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "Introduction to Networkd"
-sidebar_position: 151
+sidebar_position: 150
 ---
 
 ## Introduction 

--- a/labs/docs/documentation/developers/internals/zos/performance/performance.md
+++ b/labs/docs/documentation/developers/internals/zos/performance/performance.md
@@ -1,6 +1,6 @@
 ---
 title: "Performance Monitor Package"
-sidebar_position: 146
+sidebar_position: 143
 ---
 
 ## Overview

--- a/labs/docs/documentation/farmers/3node_building/2_bootstrap_image.md
+++ b/labs/docs/documentation/farmers/3node_building/2_bootstrap_image.md
@@ -76,10 +76,10 @@ That's it. Now you have a bootstrap image on Zero-OS as a bootable removable med
 For the BIOS **USB** and the UEFI **EFI IMG** images, you can do the following on Linux:
 
 ```
-sudo dd status=progress if=FILELOCATION.ISO(or .IMG) of=/dev/sdX
+sudo dd status=progress if=FILELOCATION of=/dev/sdX
 ```
 
-Simply replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
+Replace `FILELOCATION` by the path to the image you downloaded (the `.ISO` or the `.IMG` file), and replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
 
 If you USB key is not new, make sure to format it before burning the Zero-OS image.
 

--- a/labs/docs/documentation/farmers/3node_building/6_boot_3node.md
+++ b/labs/docs/documentation/farmers/3node_building/6_boot_3node.md
@@ -90,7 +90,7 @@ rm version.info netboot.tar.gz
 
 rm pxelinux.cfg/default
 
-chmod 777 /srv/tftp/pxelinux.cfg (optional if next step fails)
+chmod 777 /srv/tftp/pxelinux.cfg   # optional, only needed if the next step fails
 
 echo 'default ipxe-prod.lkrn' >> pxelinux.cfg/default
 ```

--- a/labs/docs/documentation/system_administrators/advanced/ecommerce/nopcommerce.md
+++ b/labs/docs/documentation/system_administrators/advanced/ecommerce/nopcommerce.md
@@ -38,7 +38,7 @@ We create an SSH tunnel with port 5432:80, as it is this combination that we wil
 
 - Open a terminal and create an SSH tunnel
     ```
-    ssh -4 -L 5432:127.0.0.1:80 root@VM_IPv4_address>
+    ssh -4 -L 5432:127.0.0.1:80 root@<VM_IPv4_address>
     ```
 
 Simply leave this window open and follow the next steps.
@@ -49,7 +49,7 @@ We prepare the full to run nopCommerce.
 
 * Connect to the VM via SSH
     ``` 
-    ssh root@VM_IPv4_address
+    ssh root@<VM_IPv4_address>
     ```
 * Update the VM
    ```

--- a/labs/docs/documentation/system_administrators/advanced/token_transfer_keygenerator.md
+++ b/labs/docs/documentation/system_administrators/advanced/token_transfer_keygenerator.md
@@ -81,4 +81,4 @@ Behind the scenes, following will happen:
 - Transferred TFTs from Stellar will be sent from the Stellar vault account to the user's Stellar account
 - TFTs will be burned on the TFChain for the transferred amount
 
-Example: ![](./img/swap_to_stellar.png ':size=400'.md)
+Example: ![](./img/swap_to_stellar.png)

--- a/labs/docs/documentation/tfconnect_toc/tfconnect_identity.md
+++ b/labs/docs/documentation/tfconnect_toc/tfconnect_identity.md
@@ -1,6 +1,6 @@
 ---
 title: "Identity"
-sidebar_position: 74
+sidebar_position: 73
 ---
 
 # ThreeFold Connect Identity

--- a/labs/docs/knowledge_base/releasenotes_readme/releasenotes_readme.md
+++ b/labs/docs/knowledge_base/releasenotes_readme/releasenotes_readme.md
@@ -1,6 +1,6 @@
 ---
 title: "Release Notes"
-sidebar_position: 362
+sidebar_position: 361
 ---
 
 # ThreeFold Grid Release Notes

--- a/labs/docs/knowledge_base/releasenotes_readme/tfgrid_release_3_0_a2.md
+++ b/labs/docs/knowledge_base/releasenotes_readme/tfgrid_release_3_0_a2.md
@@ -84,7 +84,7 @@ https://github.com/threefoldtech/zos/releases
 
 ## QSFS
 
-TODO
+See the [Quantum Safe Filesystem](../technology_toc/primitives_toc/storage_toc/qsfs) documentation.
 
 ## gridproxy v1.0.0-rc8
 
@@ -183,7 +183,7 @@ Following list is incomplete but gives some issues to think about.
 
 ## QSFS
 
-TODO
+See the [Quantum Safe Filesystem](../technology_toc/primitives_toc/storage_toc/qsfs) documentation.
 
 
 - [TFgrid 3.0 announcement](https://forum.threefold.io/t/announcement-of-tfgrid-3-0/1132)

--- a/labs/docs/knowledge_base/technology_toc/smartcontract_toc/smartcontract_tfgrid3.md
+++ b/labs/docs/knowledge_base/technology_toc/smartcontract_toc/smartcontract_tfgrid3.md
@@ -86,7 +86,7 @@ Usage of SU, CU and NU will be computed based on the prices and the rules that T
 
 Billing will be done in Database Tokens and will be send to the corresponding farmer. If the user runs out of funds the chain will set the contract state to `cancelled` or it will be removed from storage. The Node needs to act on this 'contract cancelled' event and decommission the workload.
 
-The main currency of this chain. More information on this is explained here: TODO
+The main currency of this chain. For more information, see the [ThreeFold Token](../../../documentation/threefold_token) documentation.
 
 ## Notes
 


### PR DESCRIPTION
Fixes all five findings from the full-manual scan. Scanned 459 markdown files, 1322 code blocks, 568 image references.

## 1. A broken image was rendering as raw text

`token_transfer_keygenerator.md:84` carried leftover **docsify** sizing syntax from before the Docusaurus migration:

```
![](./img/swap_to_stellar.png ':size=400'.md)
```

Docusaurus does not parse that, so readers saw the literal markdown string and no image — confirmed in the built HTML, where the only `<img>` tags on the page were the site logo. Verified after the fix: the page now emits a real `<img src="/assets/images/swap_to_stellar-….png">` and the raw markdown is gone.

## 2. Prose inside command blocks (copy-paste hazards)

Both are shell syntax errors if pasted — same class as the wipefs bug in #858, though these only fail rather than destroy:

```bash
sudo dd status=progress if=FILELOCATION.ISO(or .IMG) of=/dev/sdX
chmod 777 /srv/tftp/pxelinux.cfg (optional if next step fails)
```

The `dd` line sits in the bootstrap-image guide that every DIY farmer walks through, in **both** trees. The parenthetical is now prose, and the chmod note is a proper shell comment.

## 3. Stray angle bracket in an SSH command

`nopcommerce.md`: `root@VM_IPv4_address>` → `root@<VM_IPv4_address>`. The second `ssh` command in the same file used a bare placeholder, so I aligned it too — the file is now internally consistent and matches the convention used elsewhere (e.g. `minio_helm3.md`).

The odd-looking `5432:80` port mapping is **intentional** — the surrounding prose explains it — so it was left alone.

## 4. Reader-visible TODOs replaced with real pointers

Bare `TODO` appearing as body text on published pages:

- Two `## QSFS` / `TODO` sections in the 3.0-a2 release notes → now link to the Quantum Safe Filesystem page
- `smartcontract_tfgrid3.md`: "explained here: TODO" → now links to the ThreeFold Token page

## 5. Four duplicate `sidebar_position` values

Two pages competing for one slot leaves sidebar order arbitrary. Each moved into a free adjacent slot so nothing cascades:

| page | change | why |
| --- | --- | --- |
| `network/introduction.md` | 151 → 150 | slot free; introduction should precede mesh |
| `performance/performance.md` | 146 → 143 | "Performance Monitor Package" is the overview for that folder |
| `tfconnect_identity.md` | 74 → 73 | slot free; keeps current rendered order |
| `releasenotes_readme.md` | 362 → 361 | index page sorts before the newest release note |

Re-scanned afterwards: **0 collisions remain** anywhere in the manual.

## The new CI caught my mistake

My first attempt at (4) linked to `.../threefold_token/threefold_token`, which does not exist — that file is its folder's index, so the URL is `.../threefold_token`. The `onBrokenLinks: 'throw'` build added in #860 **failed the build and named the exact link**. Fixed and rebuilt clean. That is the check earning its keep on the very next PR.

## Deliberately not changed

- **~30 shell blocks that "fail" `bash -n`** — `<placeholder>` angle brackets (valid documentation convention) and terminal transcripts tagged as `bash`. Not bugs.
- **`#gh-light-mode-only` images** on the farmers intro looked broken but are correct: there is a CSS rule at `custom.css:311` and the URL fragment survives the asset pipeline, so the selector matches.
- **farmers/ vs labs/ drift** — all five shared pages differ by 70–160 lines. That is by design (V4 simplified vs V3 full), but it is a standing maintenance trap and worth a separate decision.