### PR TITLE
Dev to Master Sync: full-manual scan fixes

### DIFF
--- a/farmers/docs/3node_building/2_bootstrap_image.md
+++ b/farmers/docs/3node_building/2_bootstrap_image.md
@@ -70,10 +70,10 @@ That's it. Now you have a bootstrap image on Zero-OS as a bootable removable med
 For the BIOS **USB** and the UEFI **EFI IMG** images, you can do the following on Linux:
 
 ```
-sudo dd status=progress if=FILELOCATION.ISO(or .IMG) of=/dev/sdX
+sudo dd status=progress if=FILELOCATION of=/dev/sdX
 ```
 
-Simply replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
+Replace `FILELOCATION` by the path to the image you downloaded (the `.ISO` or the `.IMG` file), and replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
 
 If you USB key is not new, make sure to format it before burning the Zero-OS image.
 

--- a/labs/docs/documentation/developers/internals/zos/internal_modules/network/introduction.md
+++ b/labs/docs/documentation/developers/internals/zos/internal_modules/network/introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "Introduction to Networkd"
-sidebar_position: 151
+sidebar_position: 150
 ---
 
 ## Introduction 

--- a/labs/docs/documentation/developers/internals/zos/performance/performance.md
+++ b/labs/docs/documentation/developers/internals/zos/performance/performance.md
@@ -1,6 +1,6 @@
 ---
 title: "Performance Monitor Package"
-sidebar_position: 146
+sidebar_position: 143
 ---
 
 ## Overview

--- a/labs/docs/documentation/farmers/3node_building/2_bootstrap_image.md
+++ b/labs/docs/documentation/farmers/3node_building/2_bootstrap_image.md
@@ -76,10 +76,10 @@ That's it. Now you have a bootstrap image on Zero-OS as a bootable removable med
 For the BIOS **USB** and the UEFI **EFI IMG** images, you can do the following on Linux:
 
 ```
-sudo dd status=progress if=FILELOCATION.ISO(or .IMG) of=/dev/sdX
+sudo dd status=progress if=FILELOCATION of=/dev/sdX
 ```
 
-Simply replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
+Replace `FILELOCATION` by the path to the image you downloaded (the `.ISO` or the `.IMG` file), and replace `X` by the proper disk for your USB key. To see your disks, write `lsblk` in the command line. Make sure you select the proper disk!
 
 If you USB key is not new, make sure to format it before burning the Zero-OS image.
 

--- a/labs/docs/documentation/farmers/3node_building/6_boot_3node.md
+++ b/labs/docs/documentation/farmers/3node_building/6_boot_3node.md
@@ -90,7 +90,7 @@ rm version.info netboot.tar.gz
 
 rm pxelinux.cfg/default
 
-chmod 777 /srv/tftp/pxelinux.cfg (optional if next step fails)
+chmod 777 /srv/tftp/pxelinux.cfg   # optional, only needed if the next step fails
 
 echo 'default ipxe-prod.lkrn' >> pxelinux.cfg/default
 ```

--- a/labs/docs/documentation/system_administrators/advanced/ecommerce/nopcommerce.md
+++ b/labs/docs/documentation/system_administrators/advanced/ecommerce/nopcommerce.md
@@ -38,7 +38,7 @@ We create an SSH tunnel with port 5432:80, as it is this combination that we wil
 
 - Open a terminal and create an SSH tunnel
     ```
-    ssh -4 -L 5432:127.0.0.1:80 root@VM_IPv4_address>
+    ssh -4 -L 5432:127.0.0.1:80 root@<VM_IPv4_address>
     ```
 
 Simply leave this window open and follow the next steps.
@@ -49,7 +49,7 @@ We prepare the full to run nopCommerce.
 
 * Connect to the VM via SSH
     ``` 
-    ssh root@VM_IPv4_address
+    ssh root@<VM_IPv4_address>
     ```
 * Update the VM
    ```

--- a/labs/docs/documentation/system_administrators/advanced/token_transfer_keygenerator.md
+++ b/labs/docs/documentation/system_administrators/advanced/token_transfer_keygenerator.md
@@ -81,4 +81,4 @@ Behind the scenes, following will happen:
 - Transferred TFTs from Stellar will be sent from the Stellar vault account to the user's Stellar account
 - TFTs will be burned on the TFChain for the transferred amount
 
-Example: ![](./img/swap_to_stellar.png ':size=400'.md)
+Example: ![](./img/swap_to_stellar.png)

--- a/labs/docs/documentation/tfconnect_toc/tfconnect_identity.md
+++ b/labs/docs/documentation/tfconnect_toc/tfconnect_identity.md
@@ -1,6 +1,6 @@
 ---
 title: "Identity"
-sidebar_position: 74
+sidebar_position: 73
 ---
 
 # ThreeFold Connect Identity

--- a/labs/docs/knowledge_base/releasenotes_readme/releasenotes_readme.md
+++ b/labs/docs/knowledge_base/releasenotes_readme/releasenotes_readme.md
@@ -1,6 +1,6 @@
 ---
 title: "Release Notes"
-sidebar_position: 362
+sidebar_position: 361
 ---
 
 # ThreeFold Grid Release Notes

--- a/labs/docs/knowledge_base/releasenotes_readme/tfgrid_release_3_0_a2.md
+++ b/labs/docs/knowledge_base/releasenotes_readme/tfgrid_release_3_0_a2.md
@@ -84,7 +84,7 @@ https://github.com/threefoldtech/zos/releases
 
 ## QSFS
 
-TODO
+See the [Quantum Safe Filesystem](../technology_toc/primitives_toc/storage_toc/qsfs) documentation.
 
 ## gridproxy v1.0.0-rc8
 
@@ -183,7 +183,7 @@ Following list is incomplete but gives some issues to think about.
 
 ## QSFS
 
-TODO
+See the [Quantum Safe Filesystem](../technology_toc/primitives_toc/storage_toc/qsfs) documentation.
 
 
 - [TFgrid 3.0 announcement](https://forum.threefold.io/t/announcement-of-tfgrid-3-0/1132)

--- a/labs/docs/knowledge_base/technology_toc/smartcontract_toc/smartcontract_tfgrid3.md
+++ b/labs/docs/knowledge_base/technology_toc/smartcontract_toc/smartcontract_tfgrid3.md
@@ -86,7 +86,7 @@ Usage of SU, CU and NU will be computed based on the prices and the rules that T
 
 Billing will be done in Database Tokens and will be send to the corresponding farmer. If the user runs out of funds the chain will set the contract state to `cancelled` or it will be removed from storage. The Node needs to act on this 'contract cancelled' event and decommission the workload.
 
-The main currency of this chain. More information on this is explained here: TODO
+The main currency of this chain. For more information, see the [ThreeFold Token](../../../documentation/threefold_token) documentation.
 
 ## Notes
 


### PR DESCRIPTION
Syncs `development` to `master`. Contains #864 — fixes a broken image that rendered as raw text, two copy-paste hazards in command blocks, a stray angle bracket in an SSH command, three reader-visible TODOs, and four duplicate sidebar_position values.